### PR TITLE
Mask instead of compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,10 @@ Power Transforms:
 <font-awesome-icon icon="spinner" :transform="{ rotate: 42 }" />
 ```
 
-Composition:
+Masking:
 
 ```javascript
-<font-awesome-icon icon="coffee" :compose="['far', 'circle']" />
+<font-awesome-icon icon="coffee" :mask="['far', 'circle']" />
 ```
 
 Symbols:

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "@fortawesome/fontawesome": ">=0.0.21",
+    "@fortawesome/fontawesome": ">=0.0.22",
     "vue": "^2.4.2"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome": ">=0.0.18",
+    "@fortawesome/fontawesome": ">=0.0.22",
     "babel-core": "^6.26.0",
     "babel-jest": "^21.2.0",
     "babel-plugin-external-helpers": "^6.22.0",

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -44,7 +44,7 @@ export default {
       type: [Object, Array, String],
       required: true
     },
-    compose: {
+    mask: {
       type: [Object, Array, String],
       default: null
     },
@@ -88,19 +88,19 @@ export default {
   render (createElement, context) {
     const { props } = context
 
-    const { icon: iconArgs, compose: composeArgs, symbol } = props
+    const { icon: iconArgs, mask: maskArgs, symbol } = props
     const icon = normalizeIconArgs(iconArgs)
     const classes = objectWithKey('classes', classList(props))
     const transform = objectWithKey('transform', (typeof props.transform === 'string') ? fontawesome.parse.transform(props.transform) : props.transform)
-    const compose = objectWithKey('compose', normalizeIconArgs(composeArgs))
+    const mask = objectWithKey('mask', normalizeIconArgs(maskArgs))
 
     const renderedIcon = fontawesome.icon(
       icon,
-      { ...classes, ...transform, ...compose, symbol }
+      { ...classes, ...transform, ...mask, symbol }
     )
 
     if (!renderedIcon) {
-      return log('Check not find one or more icon(s)', icon, compose)
+      return log('Check not find one or more icon(s)', icon, mask)
     }
 
     const { abstract } = renderedIcon

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -195,15 +195,15 @@ describe('using transform', () => {
   })
 })
 
-describe('compose', () => {
+describe('mask', () => {
   test('will add icon', () => {
-    const vm = mountFromProps({ icon: faCoffee, compose: faCircle })
+    const vm = mountFromProps({ icon: faCoffee, mask: faCircle })
 
     expect(vm.$el.innerHTML).toMatch(/clippath/)
   })
 
   test('will add icon referencing librbary', () => {
-    const vm = mountFromProps({ icon: ['fas', 'coffee'], compose: ['fas', 'circle'] })
+    const vm = mountFromProps({ icon: ['fas', 'coffee'], mask: ['fas', 'circle'] })
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@fortawesome/fontawesome@>=0.0.18":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-0.0.21.tgz#282cea251c730aedace61e5a74021b90c584622e"
+"@fortawesome/fontawesome@>=0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-0.0.22.tgz#ea533f9bb4edb0dd2b4bc2b7c78d1a2aa0319430"
 
 abab@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
This is in preparation for the next release of the `fontawesome` lib. It renames `compose` to `mask`.