### PR TITLE
Documentation additions to make the examples work out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Font Awesome 5 Vue component
 
 ```
 $ npm i --save @fortawesome/fontawesome
+$ npm i --save @fortawesome/fontawesome-free-solid
 $ npm i --save @fortawesome/vue-fontawesome
 ```
 
@@ -15,6 +16,7 @@ or
 
 ```
 $ yarn add @fortawesome/fontawesome
+$ yarn add @fortawesome/fontawesome-free-solid
 $ yarn add @fortawesome/vue-fontawesome
 ```
 
@@ -93,6 +95,7 @@ App.js
 ```javascript
 import Vue from 'vue'
 import Main from './Main.vue'
+import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 import fontawesome from '@fortawesome/fontawesome'
 import brands from '@fortawesome/fontawesome-free-brands'
 import faSpinner from '@fortawesome/fontawesome-free-solid/faSpinner'


### PR DESCRIPTION
It took me some time to figure out that the fontawesome-free-solid library referenced in the examples required an explicit installation, so I added that to the installation section.

Also, the "full example" FAExample refers to FontAwesomeIcon, which is not explicitly imported in the App.js code. I added that too.