### PR TITLE
Default prefix inherited from fontawesome fix

### DIFF
--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -17,7 +17,8 @@ function normalizeIconArgs (icon) {
   }
 
   if (typeof icon === 'string') {
-    return { prefix: 'fas', iconName: icon }
+    const { familyPrefix } = fontawesome.config
+    return { prefix: familyPrefix, iconName: icon }
   }
 }
 

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -17,7 +17,7 @@ function normalizeIconArgs (icon) {
   }
 
   if (typeof icon === 'string') {
-    const { familyPrefix } = fontawesome.config
+    const familyPrefix = fontawesome.config.familyPrefix || 'fas';
     return { prefix: familyPrefix, iconName: icon }
   }
 }


### PR DESCRIPTION
Added default prefix to inherit from fontawesome config instead of hardcoded string.