### PR TITLE
fix documentation import FontAwesomeIcon in FAExample.vue instead of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ App.js
 ```javascript
 import Vue from 'vue'
 import Main from './Main.vue'
-import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 import fontawesome from '@fortawesome/fontawesome'
 import brands from '@fortawesome/fontawesome-free-brands'
 import faSpinner from '@fortawesome/fontawesome-free-solid/faSpinner'
@@ -121,6 +120,7 @@ FAExample.vue
 </template>
 
 <script>
+import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
 export default {
   name: 'FAExample',
 


### PR DESCRIPTION
Otherwise eslint will give error that FontAwesomeIcon was never used in App.js and module FontAwesomeIcon was not found.