### PR TITLE
Accept numeric entry for LayersText 'value'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 index.js
 index.es.js
 .DS_Store
+
+# WebStorm / PHPStorm
+.idea

--- a/src/components/FontAwesomeLayersText.js
+++ b/src/components/FontAwesomeLayersText.js
@@ -9,7 +9,7 @@ export default {
 
   props: {
     value: {
-      type: String,
+      type: [String, Number],
       default: ''
     },
     transform: {
@@ -22,7 +22,7 @@ export default {
     const { props } = context
     const transform = objectWithKey('transform', (typeof props.transform === 'string') ? parse.transform(props.transform) : props.transform)
 
-    const renderedText = text(props.value, { ...transform })
+    const renderedText = text(props.value.toString(), { ...transform })
 
     const { abstract } = renderedText
 

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -19,6 +19,13 @@ test('simple text', () => {
   expect(vm.$el.innerHTML).toBe('Test')
 })
 
+test('accept number for value', () => {
+    const vm = compileAndMount('<font-awesome-layers-text :value="42" />')
+
+    expect(vm.$el.getAttribute('class')).toBe('fa-layers-text')
+    expect(vm.$el.innerHTML).toBe('42')
+})
+
 describe('transform', () => {
   test('string', () => {
     const vm = compileAndMount('<font-awesome-layers-text value="1" transform="shrink-6" />')

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,15 +16,15 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.0.tgz#6bcf6481030f59e7ffd1a40a67cd464d47780f6a"
+"@fortawesome/fontawesome-common-types@^0.2.0-2":
+  version "0.2.0-5"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.0-5.tgz#95a4ad12c0d85c6e50334d9dc0301d71fbd466e3"
 
-"@fortawesome/fontawesome-svg-core@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.0.tgz#b0ec14af25cdc11d38ede7d8c94b89b478ab67ab"
+"@fortawesome/fontawesome-svg-core@^1.2.0-7":
+  version "1.2.0-7"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.0-7.tgz#1bbe0d087c101ab76d7680f3c8928411c348ab5b"
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.0"
+    "@fortawesome/fontawesome-common-types" "^0.2.0-2"
 
 "@types/acorn@^4.0.3":
   version "4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,15 +16,15 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.0-2":
-  version "0.2.0-5"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.0-5.tgz#95a4ad12c0d85c6e50334d9dc0301d71fbd466e3"
+"@fortawesome/fontawesome-common-types@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.0.tgz#6bcf6481030f59e7ffd1a40a67cd464d47780f6a"
 
-"@fortawesome/fontawesome-svg-core@^1.2.0-7":
-  version "1.2.0-7"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.0-7.tgz#1bbe0d087c101ab76d7680f3c8928411c348ab5b"
+"@fortawesome/fontawesome-svg-core@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.0.tgz#b0ec14af25cdc11d38ede7d8c94b89b478ab67ab"
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.0-2"
+    "@fortawesome/fontawesome-common-types" "^0.2.0"
 
 "@types/acorn@^4.0.3":
   version "4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4363,3 +4363,4 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+    

--- a/yarn.lock
+++ b/yarn.lock
@@ -4363,4 +4363,3 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-    


### PR DESCRIPTION
Per the description, simple change so that a numeric value will display properly. Includes a unit test for this case.

I also added a .gitignore listing for .idea, the PHPStorm / WebStorm settings folder so that it doesn't copy in to the project. I and others will benefit from this.

While pulling the NPM packages, Yarn ended up editing the yarn.lock file, I am not sure why (I did not command a refresh), I reverted the changes but am having trouble restoring the original end of file "newline". Otherwise there are no material changes to yarn.lock