### PR TITLE
Fixed rotation type.

### DIFF
--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -62,9 +62,9 @@ export default {
       default: false
     },
     rotation: {
-      type: Number,
+      type: String,
       default: null,
-      validator: (value) => [90, 180, 270].indexOf(value) > -1
+      validator: (value) => ['90', '180', '270'].indexOf(value) > -1
     },
     size: {
       type: String,


### PR DESCRIPTION
According to [your documentation](https://github.com/FortAwesome/vue-fontawesome#basic), you can pass `rotation="90"`, `rotation="180"` and `rotation="270"`. This throws the following warning:

```
[Vue warn]: Invalid prop: type check failed for prop "rotation". Expected Number, got String.
```

This is because...

```
rotation="5" // passes String
:rotation="5" // passes Number
```

Reference: https://github.com/vuejs/vue/issues/1704#issuecomment-153790398