### PR TITLE
Added note regarding multi-word icon names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 library.add(faSpinner)
 ```
 
+In the event that you are using an icon with a multi-word name please note that
+you would need to pass in the icon name using _kebab-case_ as opposed to _camelCase_.
+
+```javascript
+<font-awesome-icon icon="address-card" />
+```
+
 #### Explicit prefix (note the Vue bind shorthand because this uses an array)
 
 ```javascript


### PR DESCRIPTION
Added in a small note in the README specifying that multi-word icon names when passed in as strings should be in _kebab-case_ as opposed to _kebabCase_ as discussed in #114. If I need to make any changes or anything just let me know. Thanks!