### PR TITLE
Fix README.md's tree shaking example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ icons than you intend**. Here are some alternative import syntaxes:
 
 ```javascript
 import { library } from '@fortawesome/fontawesome-svg-core'
-import faCoffee from '@fortawesome/free-solid-svg-icons/faCoffee'
-import faSpinner from '@fortawesome/pro-light-svg-icons/faSpinner'
+import { faCoffee } from '@fortawesome/free-solid-svg-icons/faCoffee'
+import { faSpinner } from '@fortawesome/pro-light-svg-icons/faSpinner'
 
 library.add(faCoffee, faSpinner)
 ```


### PR DESCRIPTION
From 5.1.0, [package structures have been changed and import statement for each icons also have changed](https://github.com/FortAwesome/Font-Awesome/issues/12966).
[Official document](https://fontawesome.com/how-to-use/with-the-api/other/tree-shaking#deep-imports) is also correctly reflecting those changes, but not this repository's README.md

I followed this repository's example code, and kept getting errors. This caused me some headaches, so I'm making a PR.