### PR TITLE
Fixed typings (#177)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,8 @@
-declare module '@fortawesome/vue-fontawesome' {
-  import { FunctionalComponentOptions } from 'vue'
-  import { PropsDefinition } from 'vue/types/options'
-  interface FontAwesomeIconProps { }
-  interface FontAwesomeLayersProps { }
-  interface FontAwesomeLayersTextProps { }
-  export const FontAwesomeIcon: FunctionalComponentOptions<FontAwesomeIconProps, PropsDefinition<FontAwesomeIconProps>>
-  export const FontAwesomeLayers: FunctionalComponentOptions<FontAwesomeLayersProps, PropsDefinition<FontAwesomeLayersProps>>
-  export const FontAwesomeLayersText: FunctionalComponentOptions<FontAwesomeLayersTextProps, PropsDefinition<FontAwesomeLayersTextProps>>
-}
+import { FunctionalComponentOptions } from 'vue'
+import { PropsDefinition } from 'vue/types/options'
+interface FontAwesomeIconProps { }
+interface FontAwesomeLayersProps { }
+interface FontAwesomeLayersTextProps { }
+export const FontAwesomeIcon: FunctionalComponentOptions<FontAwesomeIconProps, PropsDefinition<FontAwesomeIconProps>>
+export const FontAwesomeLayers: FunctionalComponentOptions<FontAwesomeLayersProps, PropsDefinition<FontAwesomeLayersProps>>
+export const FontAwesomeLayersText: FunctionalComponentOptions<FontAwesomeLayersTextProps, PropsDefinition<FontAwesomeLayersTextProps>>


### PR DESCRIPTION
- Fixed typings as it was declaring its own node_modules as a module, which is unnecessary, and some IDEs can't interpret it.