### PR TITLE
[Docs] Explicit Icon via Computed property

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ library.add(faSpinner)
 ```javascript
 <template>
   <div id="app">
-    <font-awesome-icon icon="appIcon" />
+    <font-awesome-icon :icon="appIcon" />
   </div>
 </template>
 


### PR DESCRIPTION
Was following the documentation and came to the 
`Explicit icon definition through something like a computed property`
section. 

I adapted the example into my code, adding a computed property that returns a fontawesome icon from `@fortawesome/free-regular-svg-icons` 

```Javascript
import { faClock } from "@fortawesome/free-regular-svg-icons";

appIcon () {
    return faClock;
}
```

then following the syntax of 
```<font-awesome-icon icon="appIcon" />```

This did not work, as the icon did not appear. I instead did
```<font-awesome-icon :icon="appIcon" />```

And the icon appeared as expected.

I believe this should be changed.