### PR TITLE
Add TSX support to Typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
-import { FunctionalComponentOptions } from 'vue'
+import { FunctionalComponentOptions, VueConstructor } from 'vue'
 import { PropsDefinition } from 'vue/types/options'
 interface FontAwesomeIconProps { }
 interface FontAwesomeLayersProps { }
 interface FontAwesomeLayersTextProps { }
-export const FontAwesomeIcon: FunctionalComponentOptions<FontAwesomeIconProps, PropsDefinition<FontAwesomeIconProps>>
+export const FontAwesomeIcon: FunctionalComponentOptions<FontAwesomeIconProps, PropsDefinition<FontAwesomeIconProps>> & VueConstructor
 export const FontAwesomeLayers: FunctionalComponentOptions<FontAwesomeLayersProps, PropsDefinition<FontAwesomeLayersProps>>
 export const FontAwesomeLayersText: FunctionalComponentOptions<FontAwesomeLayersTextProps, PropsDefinition<FontAwesomeLayersTextProps>>


### PR DESCRIPTION
As discussed [in this issue](https://github.com/FortAwesome/vue-fontawesome/issues/24#issuecomment-539181000), this change allows the usage of FontAwesome in Typescript JSX constructs like so:

```tsx
render() {
  return (
    <FontAwesomeIcon icon="chevron-left" />
  )
}
```