### PR TITLE
Fixes toggling v-show fails with icon and layers text

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -458,7 +458,9 @@ var FontAwesomeIcon = defineComponent({
       return renderedIcon.value ? convert(renderedIcon.value.abstract[0], {}, attrs) : null;
     });
     return function () {
-      return vnode.value;
+      return h(function () {
+        return vnode.value;
+      });
     };
   }
 });
@@ -538,7 +540,9 @@ var FontAwesomeLayersText = defineComponent({
       return convert(abstractElement.value, {}, attrs);
     });
     return function () {
-      return vnode.value;
+      return h(function () {
+        return vnode.value;
+      });
     };
   }
 });

--- a/index.js
+++ b/index.js
@@ -461,7 +461,9 @@
 	      return renderedIcon.value ? convert(renderedIcon.value.abstract[0], {}, attrs) : null;
 	    });
 	    return function () {
-	      return vnode.value;
+	      return vue.h(function () {
+	        return vnode.value;
+	      });
 	    };
 	  }
 	});
@@ -541,7 +543,9 @@
 	      return convert(abstractElement.value, {}, attrs);
 	    });
 	    return function () {
-	      return vnode.value;
+	      return vue.h(function () {
+	        return vnode.value;
+	      });
 	    };
 	  }
 	});

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -1,5 +1,5 @@
 import { parse as faParse, icon as faIcon } from '@fortawesome/fontawesome-svg-core'
-import { defineComponent, computed, watch } from 'vue'
+import { defineComponent, computed, watch, h } from 'vue'
 import convert from '../converter'
 import log from '../logger'
 import { objectWithKey, classList } from '../utils'
@@ -122,6 +122,6 @@ export default defineComponent({
     }, { immediate: true })
 
     const vnode = computed(() => renderedIcon.value ? convert(renderedIcon.value.abstract[0], {}, attrs) : null)
-    return () => vnode.value
+    return () => h(() => vnode.value)
   }
 })

--- a/src/components/FontAwesomeLayersText.js
+++ b/src/components/FontAwesomeLayersText.js
@@ -1,5 +1,5 @@
 import { config, parse, text } from '@fortawesome/fontawesome-svg-core'
-import { defineComponent, computed } from 'vue'
+import { defineComponent, computed, h } from 'vue'
 import convert from '../converter'
 import { objectWithKey } from '../utils'
 
@@ -44,6 +44,6 @@ export default defineComponent({
     })
 
     const vnode = computed(() => convert(abstractElement.value, {}, attrs))
-    return () => vnode.value
+    return () => h(() => vnode.value)
   }
 })


### PR DESCRIPTION
Fixes #313 

`v-show` didn't work when used directly on `<font-awesome-icon>` after the reactivity change.
It did work when it was wrapped in another element like a div or as a root element in a wrapper component.
I changed the icon and layers text so that the returned value is wrapped in `h()` which I suspect is the same thing that happens when it's the root element of a wrapper component.

I couldn't find a way to test it automatically. I tried `compileAndMount` with `v-show` but it didn't fail. Could be that the problem was introduced somewhere between Vue 3.0.0 and 3.0.11 but the current test utils version doesn't work with 3.0.11. I did test it manually and toggling `v-show` no longer failed.