### PR TITLE
Fix comment syntax in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Using the Pro packages requires [additional configuration](https://fontawesome.c
 
 ```javascript
 import { library } from '@fortawesome/fontawesome-svg-core'
-# Note we are using the Pro style here
+// Note we are using the Pro style here
 import { faUserSecret } from '@fortawesome/pro-regular-svg-icons'
 
 library.add(faUserSecret)
@@ -234,7 +234,7 @@ library.add(faUserSecret)
 
 ```javascript
 import { library } from '@fortawesome/fontawesome-svg-core'
-# Note we are using the Pro style here
+// Note we are using the Pro style here
 import { faUserSecret } from '@fortawesome/pro-light-svg-icons'
 
 library.add(faUserSecret)
@@ -248,7 +248,7 @@ library.add(faUserSecret)
 
 ```javascript
 import { library } from '@fortawesome/fontawesome-svg-core'
-# Note we are using the Pro style here
+// Note we are using the Pro style here
 import { faUserSecret } from '@fortawesome/pro-duotone-svg-icons'
 
 library.add(faUserSecret)
@@ -304,8 +304,8 @@ The `icon` property of the `FontAwesomeIcon` component can be used in the follow
 <font-awesome-icon icon="spinner" />
 <font-awesome-icon icon="align-left" />
 
-<font-awesome-icon :icon="['fas', 'spinner']" /> # Same as above
-<font-awesome-icon :icon="['fas', 'align-left']" /> # Same as above
+<font-awesome-icon :icon="['fas', 'spinner']" /> // Same as above
+<font-awesome-icon :icon="['fas', 'align-left']" /> // Same as above
 ```
 
 For the above to work you must add the `spinner` and `align-left` icon to the library.
@@ -321,7 +321,7 @@ In the event that you are using an icon with a multi-word name please note that
 you would need to pass in the icon name using _kebab-case_ as opposed to _camelCase_.
 
 ```javascript
-<font-awesome-icon icon="address-card" />  # import { faAddressCard } from '@fortawesome/free-solid-svg-icons'
+<font-awesome-icon icon="address-card" />  // import { faAddressCard } from '@fortawesome/free-solid-svg-icons'
 ```
 
 #### Explicit prefix (note the Vue bind shorthand because this uses an array)


### PR DESCRIPTION
Hi, Font Awesome team

The comment syntax in README.md for javascript is wrong.

Maybe you should do the same fix for 3.x branch.