### PR TITLE
add icons using string format to vue3

### DIFF
--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -5,6 +5,14 @@ import log from '../logger'
 import { objectWithKey, classList } from '../utils'
 
 function normalizeIconArgs (icon) {
+  if (icon && typeof icon === 'object' && icon.prefix && icon.iconName && icon.icon) {
+    return icon
+  }
+
+  if (faParse.icon) {
+    return faParse.icon(icon)
+  }
+
   if (icon === null) {
     return null
   }

--- a/src/components/__fixtures__/icons.js
+++ b/src/components/__fixtures__/icons.js
@@ -21,3 +21,15 @@ export const faCircle = {
     "..."
   ]
 }
+
+export const faAlien = {
+  prefix: 'fad',
+  iconName: 'alien',
+  icon: [
+    640,
+    512,
+    [],
+    "f003",
+    "..."
+  ]
+}

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -12,7 +12,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  fontawesome.library.reset()
+  library.reset()
 })
 
 test('using array format, short prefix and short icon name', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -2,63 +2,67 @@
  * @jest-environment jsdom
  */
 
- import { library } from '@fortawesome/fontawesome-svg-core'
- import { faCoffee, faCircle, faAlien } from '../__fixtures__/icons'
- import { compileAndMount, mountFromProps } from '../__fixtures__/helpers'
- import FontAwesomeIcon from '../FontAwesomeIcon'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCoffee, faCircle, faAlien } from '../__fixtures__/icons'
+import { compileAndMount, mountFromProps } from '../__fixtures__/helpers'
+import FontAwesomeIcon from '../FontAwesomeIcon'
 
- beforeEach(() => {
-   library.add(faCoffee, faCircle, faAlien)
- })
+beforeEach(() => {
+  library.add(faCoffee, faCircle, faAlien)
+})
 
- test('using array format, short prefix and short icon name', () => {
-   const wrapper = mountFromProps({ icon: ['fas', 'coffee'] })
+afterEach(() => {
+  fontawesome.library.reset()
+})
 
-   expect(wrapper.element.tagName).toBe('svg')
-   expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
- })
+test('using array format, short prefix and short icon name', () => {
+  const wrapper = mountFromProps({ icon: ['fas', 'coffee'] })
 
- test('using array format, short prefix and long icon name', () => {
-   const wrapper = mountFromProps({ icon: ['fas', 'fa-coffee'] })
+  expect(wrapper.element.tagName).toBe('svg')
+  expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
+})
 
-   expect(wrapper.element.tagName).toBe('svg')
-   expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
- })
+test('using array format, short prefix and long icon name', () => {
+  const wrapper = mountFromProps({ icon: ['fas', 'fa-coffee'] })
 
- test('using array format, long prefix and long icon name', () => {
-   const wrapper = mountFromProps({ icon: ['fa-solid', 'fa-coffee'] })
+  expect(wrapper.element.tagName).toBe('svg')
+  expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
+})
 
-   expect(wrapper.element.tagName).toBe('svg')
-   expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
- })
+test('using array format, long prefix and long icon name', () => {
+  const wrapper = mountFromProps({ icon: ['fa-solid', 'fa-coffee'] })
 
- test('using array format, long prefix and short icon name', () => {
-   const wrapper = mountFromProps({ icon: ['fa-duotone', 'alien'] })
+  expect(wrapper.element.tagName).toBe('svg')
+  expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
+})
 
-   expect(wrapper.element.tagName).toBe('svg')
-   expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
- })
+test('using array format, long prefix and short icon name', () => {
+  const wrapper = mountFromProps({ icon: ['fa-duotone', 'alien'] })
 
- test('using string format, icon name only', () => {
-   const wrapper = mountFromProps({ icon: 'coffee' })
+  expect(wrapper.element.tagName).toBe('svg')
+  expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
+})
 
-   expect(wrapper.element.tagName).toBe('svg')
-   expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
- })
+test('using string format, icon name only', () => {
+  const wrapper = mountFromProps({ icon: 'coffee' })
 
- test('using string format, with long prefix and long icon name', () => {
-   const wrapper = mountFromProps({ icon: 'fa-duotone fa-alien' })
+  expect(wrapper.element.tagName).toBe('svg')
+  expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
+})
 
-   expect(wrapper.element.tagName).toBe('svg')
-   expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
- })
+test('using string format, with long prefix and long icon name', () => {
+  const wrapper = mountFromProps({ icon: 'fa-duotone fa-alien' })
 
- test('using string format, with short prefix and long icon name', () => {
-   const wrapper = mountFromProps({ icon: 'fad fa-alien' })
+  expect(wrapper.element.tagName).toBe('svg')
+  expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
+})
 
-   expect(wrapper.element.tagName).toBe('svg')
-   expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
- })
+test('using string format, with short prefix and long icon name', () => {
+  const wrapper = mountFromProps({ icon: 'fad fa-alien' })
+
+  expect(wrapper.element.tagName).toBe('svg')
+  expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
+})
 
 test('missing icon', () => {
   const wrapper = mountFromProps({ icon: ['fas', 'noicon'] })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -2,28 +2,63 @@
  * @jest-environment jsdom
  */
 
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { faCoffee, faCircle } from '../__fixtures__/icons'
-import { compileAndMount, mountFromProps } from '../__fixtures__/helpers'
-import FontAwesomeIcon from '../FontAwesomeIcon'
+ import { library } from '@fortawesome/fontawesome-svg-core'
+ import { faCoffee, faCircle, faAlien } from '../__fixtures__/icons'
+ import { compileAndMount, mountFromProps } from '../__fixtures__/helpers'
+ import FontAwesomeIcon from '../FontAwesomeIcon'
 
-beforeEach(() => {
-  library.add(faCoffee, faCircle)
-})
+ beforeEach(() => {
+   library.add(faCoffee, faCircle, faAlien)
+ })
 
-test('using array format', () => {
-  const wrapper = mountFromProps({ icon: ['fas', 'coffee'] })
+ test('using array format, short prefix and short icon name', () => {
+   const wrapper = mountFromProps({ icon: ['fas', 'coffee'] })
 
-  expect(wrapper.element.tagName).toBe('svg')
-  expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
-})
+   expect(wrapper.element.tagName).toBe('svg')
+   expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
+ })
 
-test('using string format', () => {
-  const wrapper = mountFromProps({ icon: 'coffee' })
+ test('using array format, short prefix and long icon name', () => {
+   const wrapper = mountFromProps({ icon: ['fas', 'fa-coffee'] })
 
-  expect(wrapper.element.tagName).toBe('svg')
-  expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
-})
+   expect(wrapper.element.tagName).toBe('svg')
+   expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
+ })
+
+ test('using array format, long prefix and long icon name', () => {
+   const wrapper = mountFromProps({ icon: ['fa-solid', 'fa-coffee'] })
+
+   expect(wrapper.element.tagName).toBe('svg')
+   expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
+ })
+
+ test('using array format, long prefix and short icon name', () => {
+   const wrapper = mountFromProps({ icon: ['fa-duotone', 'alien'] })
+
+   expect(wrapper.element.tagName).toBe('svg')
+   expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
+ })
+
+ test('using string format, icon name only', () => {
+   const wrapper = mountFromProps({ icon: 'coffee' })
+
+   expect(wrapper.element.tagName).toBe('svg')
+   expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
+ })
+
+ test('using string format, with long prefix and long icon name', () => {
+   const wrapper = mountFromProps({ icon: 'fa-duotone fa-alien' })
+
+   expect(wrapper.element.tagName).toBe('svg')
+   expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
+ })
+
+ test('using string format, with short prefix and long icon name', () => {
+   const wrapper = mountFromProps({ icon: 'fad fa-alien' })
+
+   expect(wrapper.element.tagName).toBe('svg')
+   expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
+ })
 
 test('missing icon', () => {
   const wrapper = mountFromProps({ icon: ['fas', 'noicon'] })


### PR DESCRIPTION
This PR allows us to use string format to add icons to vue3 projects.

Example:
`<font-awesome-icon icon="fa-duotone fa-coffee" size="5x" />`
`<font-awesome-icon icon="fad fa-user-secret" size="5x" />`

Previously we could only add using array syntax:
`<font-awesome-icon :icon="['fa-duotone', 'fa-coffee']" size="5x" color="red"/>`
`<font-awesome-icon :icon="['fad', 'coffee']" size="5x" />`

Requested by this issue:  [#347](https://github.com/FortAwesome/vue-fontawesome/issues/347)


Dependencies:
This PR is dependent upon and should be merged into [vue3-add-bounce-shake-tests](https://github.com/FortAwesome/vue-fontawesome/tree/vue3-add-bounce-shake-tests).
