### PR TITLE
Bug fix:  Vue 2.x documentation link is not working (temp fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@
 
 ## Documentation
 
-Official documentation is hosted at fontawesome.com: [Check it out here](https://fontawesome.com/docs/web/use-with/vue/)
+Official documentation is hosted at fontawesome.com
+
+Helpful Vue links:
+- [Add Icons with Vue](https://fontawesome.com/docs/web/use-with/vue/add-icons)
+- [Adding Icon Styling with Vue](https://fontawesome.com/docs/web/use-with/vue/style)
+
+To find the Vue setup, go to our [Web docs](https://fontawesome.com/docs/web) and click the ***"Set Up with Vue"*** (left hand side menu).
 
 ## How to Help
 


### PR DESCRIPTION
Vue 2.x documentation link is not working on our repo.

The link does take users to the Vue setup page: `https://fontawesome.com/docs/web/use-with/vue/` ; however each additional click on a link will change the url but not the page.

This is a temporary fix until we can reproduce in dev and get a proper fix in.