### PR TITLE
Vue 3 - rearrange and add ts sizes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ interface FontAwesomeIconProps {
   pulse?: boolean
   rotation?: 90 | 180 | 270 | '90' | '180' | '270'
   swapOpacity?: boolean
-  size?: 'lg' | 'xs' | 'sm' | '1x' | '2x' | '3x' | '4x' | '5x' | '6x' | '7x' | '8x' | '9x' | '10x'
+  size?: '2xs' | 'xs' | 'sm' | 'lg' | 'xl' | '2xl' | '1x' | '2x' | '3x' | '4x' | '5x' | '6x' | '7x' | '8x' | '9x' | '10x'
   spin?: boolean
   transform?: object | string
   symbol?: boolean | string


### PR DESCRIPTION
This PR will add 3 missing sizes to the `index.d.ts` file (2xs, xl, and 2xl).

Issue reference: [3.x Types Issue: FontAwesomeIconProps missing values #415](https://github.com/FortAwesome/vue-fontawesome/issues/415)