### PR TITLE
Vue 3 missing animations for ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,13 @@ interface FontAwesomeIconProps {
   symbol?: boolean | string
   title?: string
   inverse?: boolean
+  bounce?: boolean
+  shake?: boolean
+  beat?: boolean
+  fade?: boolean
+  beatFade?: boolean
+  spinPulse?: boolean
+  spinReverse?: boolean
 }
 
 interface FontAwesomeLayersProps {


### PR DESCRIPTION
This PR will add some missing animations props.

See issue here:  [3.x Types Issue: FontAwesomeIconProps missing values #428](https://github.com/FortAwesome/vue-fontawesome/issues/428)

`flash` animation not added per [Breaking Changes to the "flash" animation.](https://fontawesome.com/docs/changelog/#beta3-changed)
> The new in v6 CSS "flash" animation has been renamed to " [beat-fade](https://fontawesome.com/docs/web/style/animate#beat-fade)" to avoid collisions with v4 icon names and for more consistent animation naming.