### PR TITLE
Properly infer icons type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
-import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { IconDefinition, IconName, IconPrefix } from '@fortawesome/fontawesome-svg-core';
 import { DefineComponent } from 'vue'
 
 interface FontAwesomeIconProps {
   border?: boolean
   fixedWidth?: boolean
   flip?: 'horizontal' | 'vertical' | 'both'
-  icon: object | Array<string> | string | IconDefinition
-  mask?: object | Array<string> | string
+  icon: [IconPrefix, IconName] | IconName | IconDefinition
+  mask?: [IconPrefix, IconName] | IconName
   listItem?: boolean
   pull?: 'right' | 'left'
   pulse?: boolean


### PR DESCRIPTION
The library exposes IconPrefix, IconName and IconDefinition types, which can be used to improve developer experience by marking props definition with those. As the change is strictly related to TypeScript, I am not sure how to write tests for it. I hope somebody will take a look on it :)