### PR TITLE
Remove Node 14 from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         free-solid-svg-icons: [5.x, 6.x]
         fontawesome-svg-core: [1.2.x, 6.x]
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
         vue: [3.0.x, 3.1.x, 3.2.x, 3.3.x]
 
     steps:


### PR DESCRIPTION
Per Node releases, versions node 14 is unstable (https://nodejs.org/en/download/releases).

This PR will remove from CI.