### PR TITLE
feat: add FontAwesomeIconProps export in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,4 +44,5 @@ declare const FontAwesomeIcon: DefineComponent<FontAwesomeIconProps>
 declare const FontAwesomeLayers: DefineComponent<FontAwesomeLayersProps>
 declare const FontAwesomeLayersText: DefineComponent<FontAwesomeLayersTextProps>
 
-export { FontAwesomeIcon, FontAwesomeLayers, FontAwesomeLayersText }
+export { FontAwesomeIcon, FontAwesomeIconProps, FontAwesomeLayers, FontAwesomeLayersText }
+


### PR DESCRIPTION
This will fix the export [issue](https://github.com/FortAwesome/vue-fontawesome/issues/489) like mentioned before.

`FaIcon.vue`
``` vue
<template>
  <FontAwesomeIcon :icon="props.icon" />
</template>

<script setup lang="ts">
import { type FontAwesomeIconProps, FontAwesomeIcon } from '@fortawesome/vue-fontawesome'

// will get error with @vue/compiler-sfc
const props = defineProps<InstanceType<typeof FontAwesomeIcon>['$props']>()

// missing FontAwesomeIconProps in export
// const props = defineProps<FontAwesomeIconProps>()
</script>

<style lang="scss" scoped></style>
```

if I use `InstanceType<typeof FontAwesomeIcon>['$props']`, then error occur like this picture.

<img width="1276" alt="截圖 2024-04-02 下午2 14 15" src="https://github.com/FortAwesome/vue-fontawesome/assets/137741390/4aa3029c-5ace-4871-aab9-b3d07f6cbf41">
<br>
<br>
<br>
<br>
<br>
<br>
We except to use the code like this `const props = defineProps<FontAwesomeIconProps>()`.