### PR TITLE
Export the other props on `index.d.ts`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,4 +44,4 @@ declare const FontAwesomeIcon: DefineComponent<FontAwesomeIconProps>
 declare const FontAwesomeLayers: DefineComponent<FontAwesomeLayersProps>
 declare const FontAwesomeLayersText: DefineComponent<FontAwesomeLayersTextProps>
 
-export { FontAwesomeIcon, FontAwesomeLayers, FontAwesomeLayersText }
+export { FontAwesomeIcon, FontAwesomeIconProps, FontAwesomeLayers, FontAwesomeLayersProps, FontAwesomeLayersText, FontAwesomeLayersTextProps }


### PR DESCRIPTION
This PR will export the other props on `index.d.ts`.

This PR should help with the export declaration issues referred to in the following:
- https://github.com/FortAwesome/vue-fontawesome/pull/462#issuecomment-1920596702
- https://github.com/FortAwesome/vue-fontawesome/issues/418

Current `index.d.ts` file for reference:  https://github.com/FortAwesome/vue-fontawesome/blob/3.x/index.d.ts

@robmadole --- this look good to you for the fixes ?
