### PR TITLE
update FontAwesomeIconProps flip and mask with correct types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,10 +4,10 @@ import { DefineComponent } from 'vue'
 interface FontAwesomeIconProps {
   border?: boolean
   fixedWidth?: boolean
-  flip?: 'horizontal' | 'vertical' | 'both'
+  flip?: 'horizontal' | 'vertical' | 'both' | boolean
   icon: object | Array<string> | string | IconDefinition
   mask?: object | Array<string> | string
-  maskId?: object | Array<string> | string
+  maskId?: string
   listItem?: boolean
   pull?: 'right' | 'left'
   pulse?: boolean


### PR DESCRIPTION
This PR updates `FontAwesomeIconProps` `flip` and `mask` with correct types.
- see github issue:  [update FontAwesomeIconProps flip and mask with correct types](https://github.com/FortAwesome/vue-fontawesome/issues/534)

**Specifically, this PR:**
- adds the `boolean` type to `flip`
- removes `object` and `Array<string>` as types on `maskId` ***
- adds the `string` type to `maskId`

***Passing an object or anything other than a string to `maskId` was allowed but more or less "failing" silently: 

**The following was previously allowed (an object for the `mask-id`):**
```
<font-awesome-icon
  :icon="['fatl', 'truck']"
  transform="shrink-12"
  :mask="['fasdt', 'truck']"
  size="3x"
  :mask-id="{ foo: 'bar' }"
/>
```

**The resulting svg output was:**
```
<mask ... id="mask-[object Object]">
```

- the object was being coerced into a string

**What I found:**
The mask-id  was **not** valid with and object or an array, and anything trying to reference url(#mask-[object Object]) will fail to match, breaking the mask effect, breaking our icon --- our masked icon would not render properly.

**However:**
```
<font-awesome-icon
  :icon="['fatl', 'truck']"
  transform="shrink-12"
  :mask="['fasdt', 'truck']"
  size="3x"
  mask-id="my-mask"
/>
```

gives us the desired and expected output with the icon rendering properly:  
```
<mask id="mask-my-mask">...</mask>
```


@robmadole --- can you review for correctness ?