### PR TITLE
add layers-text tests and remove dead code

### DIFF
--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -105,7 +105,7 @@ describe('class attr', () => {
     expect(wrapper.element.classList.contains('fa-inverse')).toBe(true)
   })
 
-  test('user-provided class does not replace fa-layers-counter', () => {
+  test('user-provided class is applied alongside fa-layers-counter', () => {
     const wrapper = compileAndMount({
       template: '<font-awesome-layers-text :value="42" :counter="true" class="fa-inverse" />',
       components: {

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -93,16 +93,28 @@ describe('class attr', () => {
     expect(wrapper.element.classList.contains('gray8')).toBe(true)
   })
 
+  test('fa-inverse is applied alongside fa-layers-text', () => {
+    const wrapper = compileAndMount({
+      template: '<font-awesome-layers-text value="NEW" class="fa-inverse" />',
+      components: {
+        FontAwesomeLayersText
+      }
+    })
+
+    expect(wrapper.element.classList.contains('fa-layers-text')).toBe(true)
+    expect(wrapper.element.classList.contains('fa-inverse')).toBe(true)
+  })
+
   test('user-provided class does not replace fa-layers-counter', () => {
     const wrapper = compileAndMount({
-      template: '<font-awesome-layers-text :value="42" :counter="true" class="my-counter" />',
+      template: '<font-awesome-layers-text :value="42" :counter="true" class="fa-inverse" />',
       components: {
         FontAwesomeLayersText
       }
     })
 
     expect(wrapper.element.classList.contains('fa-layers-counter')).toBe(true)
-    expect(wrapper.element.classList.contains('my-counter')).toBe(true)
+    expect(wrapper.element.classList.contains('fa-inverse')).toBe(true)
   })
 })
 

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -80,6 +80,32 @@ describe('counter', () => {
   })
 })
 
+describe('class attr', () => {
+  test('user-provided class is applied alongside fa-layers-text', () => {
+    const wrapper = compileAndMount({
+      template: '<font-awesome-layers-text value="New!" class="gray8" />',
+      components: {
+        FontAwesomeLayersText
+      }
+    })
+
+    expect(wrapper.element.classList.contains('fa-layers-text')).toBe(true)
+    expect(wrapper.element.classList.contains('gray8')).toBe(true)
+  })
+
+  test('user-provided class does not replace fa-layers-counter', () => {
+    const wrapper = compileAndMount({
+      template: '<font-awesome-layers-text :value="42" :counter="true" class="my-counter" />',
+      components: {
+        FontAwesomeLayersText
+      }
+    })
+
+    expect(wrapper.element.classList.contains('fa-layers-counter')).toBe(true)
+    expect(wrapper.element.classList.contains('my-counter')).toBe(true)
+  })
+})
+
 describe('reactivity', () => {
   test('changing props should update the element', async () => {
     const wrapper = compileAndMount({

--- a/src/converter.js
+++ b/src/converter.js
@@ -40,25 +40,6 @@ function classToObject (classes) {
 }
 
 /**
- * Combines collections of style classes into one collection
- * @param  {Array<String | String[]>} collections The collections to combine.
- * @returns {Array<String>}
- */
-function combineClassObjects (...collections) {
-  const finalSet = new Set([])
-
-  collections.forEach(set => {
-    if (Array.isArray(set)) {
-      finalSet.forEach(className => finalSet.add(className))
-    } else {
-      finalSet.add(set)
-    }
-  })
-
-  return Array.from(finalSet)
-}
-
-/**
  * Converts a FontAwesome abstract element of an icon into a Vue VNode.
  * @param {AbstractElement | String} abstractElement The element to convert.
  * @param {Object} props The user-defined props.


### PR DESCRIPTION
This PR:
 - removes the unused `combineClassObjects` function from `converter.js` 
 - adds new tests for `FontAwesomeLayersText.test.js` for the "class attr"


@robmadole --- could you review for correctness?