### PR TITLE
Updates to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules
 .idea
 bin/act
 fortawesome-vue-fontawesome-*.tgz
+
+# Local Claude Code settings
+.claude/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ fortawesome-vue-fontawesome-*.tgz
 
 # Local Claude Code settings
 .claude/settings.json
+.claude/commands
+

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,6 +10,25 @@ The following commands are available through `npm run` or `yarn`:
 | dist    | Build a production version of the library using Rollup  |
 | test    | Execute unit tests                                      |
 
+## Testing against multiple Font Awesome SVG Core versions
+
+The library supports `@fortawesome/fontawesome-svg-core` v1 (Font Awesome 5), v6, and v7. The default devDependency is v7, but you can temporarily swap versions without modifying `package.json`:
+
+```bash
+# Test against v5
+npm install --no-save @fortawesome/fontawesome-svg-core@~1 @fortawesome/free-solid-svg-icons@~5
+npm run test
+
+# Test against v6
+npm install --no-save @fortawesome/fontawesome-svg-core@~6 @fortawesome/free-solid-svg-icons@~6
+npm run test
+
+# Restore v7
+npm install --no-save @fortawesome/fontawesome-svg-core@~7 @fortawesome/free-solid-svg-icons@~7
+```
+
+Each version runs a subset of the tests — blocks guarded by version feature flags are automatically skipped.
+
 ## Release this project
 
 **During pre release, make sure and use `--tag` and `--npm-dist-tag`**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ The following commands are available through `npm run` or `yarn`:
 
 ## Testing against multiple Font Awesome SVG Core versions
 
-The library supports `@fortawesome/fontawesome-svg-core` v1 (Font Awesome 5), v6, and v7. The default devDependency is v7, but you can temporarily swap versions without modifying `package.json`:
+The library supports `@fortawesome/fontawesome-svg-core` v1 (Font Awesome 5), v6, and v7. The default devDependency is v7, but you can temporarily swap versions without modifying `package.json`. Note that `package-lock.json` will be updated — run `git checkout -- package-lock.json` when done to restore it.
 
 ```bash
 # Test against v5
@@ -25,6 +25,9 @@ npm run test
 
 # Restore v7
 npm install --no-save @fortawesome/fontawesome-svg-core@~7 @fortawesome/free-solid-svg-icons@~7
+
+# Clean up lockfile changes
+git checkout -- package-lock.json
 ```
 
 Each version runs a subset of the tests — blocks guarded by version feature flags are automatically skipped.

--- a/src/components/__fixtures__/helpers.js
+++ b/src/components/__fixtures__/helpers.js
@@ -1,9 +1,9 @@
 import FontAwesomeIcon from '../FontAwesomeIcon'
 import pkg from '@fortawesome/fontawesome-svg-core/package.json'
 import { mount } from '@vue/test-utils'
+import { parse } from '@fortawesome/fontawesome-svg-core'
 
 const coreMajorVersion = Number.parseInt(pkg.version?.split('.')[0], 10) || 0
-const coreMinorVersion = Number.parseInt(pkg.version?.split('.')[1], 10) || 0
 
 export function compileAndMount(definition, props = {}) {
   return mount(definition, { props })
@@ -13,20 +13,23 @@ export function mountFromProps(props = {}) {
   return mount(FontAwesomeIcon, { props })
 }
 
-// Available in v6+
-export const SUPPORTS_ICON_BY_STYLE = coreMajorVersion >= 6
-export const SUPPORTS_ICON_ALIASES = coreMajorVersion >= 6
-export const SUPPORTS_ICON_USING_STRING = coreMajorVersion >= 6
-export const SUPPORTS_ICON_USING_FAMILY = coreMajorVersion >= 6
+export function coreHasFeature(feature) {
+  if (feature === REFERENCE_ICON_BY_STYLE || feature === ICON_ALIASES || feature === REFERENCE_ICON_USING_STRING || feature === REFERENCE_ICON_USING_FAMILY) {
+    return parse.icon
+  }
 
-// Available in v7+ only
-export const SUPPORTS_7X_SMALL_BATCH_ICONS = coreMajorVersion === 7
+  if (feature === REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS) {
+    return coreMajorVersion === 7
+  }
 
-// Available in v7.1+ only
-export const SUPPORTS_7X_UTILITY_ICONS = coreMajorVersion === 7 && coreMinorVersion >= 1
+  if (feature === ICON_TITLE_PROP) {
+    return coreMajorVersion < 7
+  }
+}
 
-// Available in v7.2+ only
-export const SUPPORTS_7X_GRAPHITE_ICONS = coreMajorVersion === 7 && coreMinorVersion >= 2
-
-// Available in pre-v7 only
-export const SUPPORTS_TITLE_PROP = coreMajorVersion < 7
+export const REFERENCE_ICON_BY_STYLE = 0x00
+export const ICON_ALIASES = 0x01
+export const REFERENCE_ICON_USING_STRING = 0x02
+export const REFERENCE_ICON_USING_FAMILY = 0x03
+export const REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS = 0x04
+export const ICON_TITLE_PROP = 0x06

--- a/src/components/__fixtures__/helpers.js
+++ b/src/components/__fixtures__/helpers.js
@@ -1,7 +1,6 @@
 import FontAwesomeIcon from '../FontAwesomeIcon'
 import pkg from '@fortawesome/fontawesome-svg-core/package.json'
 import { mount } from '@vue/test-utils'
-import { parse } from '@fortawesome/fontawesome-svg-core'
 
 const coreMajorVersion = Number.parseInt(pkg.version?.split('.')[0], 10) || 0
 const coreMinorVersion = Number.parseInt(pkg.version?.split('.')[1], 10) || 0
@@ -15,13 +14,16 @@ export function mountFromProps(props = {}) {
 }
 
 // Available in v6+
-export const SUPPORTS_ICON_BY_STYLE = !!parse.icon
-export const SUPPORTS_ICON_ALIASES = !!parse.icon
-export const SUPPORTS_ICON_USING_STRING = !!parse.icon
-export const SUPPORTS_ICON_USING_FAMILY = !!parse.icon
+export const SUPPORTS_ICON_BY_STYLE = coreMajorVersion >= 6
+export const SUPPORTS_ICON_ALIASES = coreMajorVersion >= 6
+export const SUPPORTS_ICON_USING_STRING = coreMajorVersion >= 6
+export const SUPPORTS_ICON_USING_FAMILY = coreMajorVersion >= 6
 
 // Available in v7+ only
 export const SUPPORTS_7X_SMALL_BATCH_ICONS = coreMajorVersion === 7
+
+// Available in v7.1+ only
+export const SUPPORTS_7X_UTILITY_ICONS = coreMajorVersion === 7 && coreMinorVersion >= 1
 
 // Available in v7.2+ only
 export const SUPPORTS_7X_GRAPHITE_ICONS = coreMajorVersion === 7 && coreMinorVersion >= 2

--- a/src/components/__fixtures__/helpers.js
+++ b/src/components/__fixtures__/helpers.js
@@ -13,6 +13,18 @@ export function mountFromProps(props = {}) {
   return mount(FontAwesomeIcon, { props })
 }
 
+export function compileWithTemplate(template, icon) {
+  return compileAndMount({
+    template,
+    data() {
+      return { icon }
+    },
+    components: {
+      FontAwesomeIcon
+    }
+  })
+}
+
 export function coreHasFeature(feature) {
   if (feature === REFERENCE_ICON_BY_STYLE || feature === ICON_ALIASES || feature === REFERENCE_ICON_USING_STRING || feature === REFERENCE_ICON_USING_FAMILY) {
     return parse.icon

--- a/src/components/__fixtures__/helpers.js
+++ b/src/components/__fixtures__/helpers.js
@@ -14,28 +14,17 @@ export function mountFromProps(props = {}) {
   return mount(FontAwesomeIcon, { props })
 }
 
-export function coreHasFeature(feature) {
-  if (feature === REFERENCE_ICON_BY_STYLE || feature === ICON_ALIASES || feature === REFERENCE_ICON_USING_STRING || feature === REFERENCE_ICON_USING_FAMILY) {
-    return parse.icon
-  }
+// Available in v6+
+export const SUPPORTS_ICON_BY_STYLE = !!parse.icon
+export const SUPPORTS_ICON_ALIASES = !!parse.icon
+export const SUPPORTS_ICON_USING_STRING = !!parse.icon
+export const SUPPORTS_ICON_USING_FAMILY = !!parse.icon
 
-  if (feature === REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS) {
-    return coreMajorVersion === 7
-  }
+// Available in v7+ only
+export const SUPPORTS_7X_SMALL_BATCH_ICONS = coreMajorVersion === 7
 
-  if (feature === REFERENCE_ICON_USING_7X_GRAPHITE_ICONS) {
-    return coreMajorVersion === 7 && coreMinorVersion >= 2
-  }
+// Available in v7.2+ only
+export const SUPPORTS_7X_GRAPHITE_ICONS = coreMajorVersion === 7 && coreMinorVersion >= 2
 
-  if (feature === ICON_TITLE_PROP) {
-    return coreMajorVersion < 7
-  }
-}
-
-export const REFERENCE_ICON_BY_STYLE = 0x00
-export const ICON_ALIASES = 0x01
-export const REFERENCE_ICON_USING_STRING = 0x02
-export const REFERENCE_ICON_USING_FAMILY = 0x03
-export const REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS = 0x04
-export const REFERENCE_ICON_USING_7X_GRAPHITE_ICONS = 0x05
-export const ICON_TITLE_PROP = 0x06
+// Available in pre-v7 only
+export const SUPPORTS_TITLE_PROP = coreMajorVersion < 7

--- a/src/components/__fixtures__/helpers.js
+++ b/src/components/__fixtures__/helpers.js
@@ -4,6 +4,7 @@ import { mount } from '@vue/test-utils'
 import { parse } from '@fortawesome/fontawesome-svg-core'
 
 const coreMajorVersion = Number.parseInt(pkg.version?.split('.')[0], 10) || 0
+const coreMinorVersion = Number.parseInt(pkg.version?.split('.')[1], 10) || 0
 
 export function compileAndMount(definition, props = {}) {
   return mount(definition, { props })
@@ -21,6 +22,10 @@ export function coreHasFeature(feature) {
   if (feature === REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS) {
     return coreMajorVersion === 7
   }
+
+  if (feature === REFERENCE_ICON_USING_7X_GRAPHITE_ICONS) {
+    return coreMajorVersion === 7 && coreMinorVersion >= 2
+  }
 }
 
 export const REFERENCE_ICON_BY_STYLE = 0x00
@@ -28,3 +33,4 @@ export const ICON_ALIASES = 0x01
 export const REFERENCE_ICON_USING_STRING = 0x02
 export const REFERENCE_ICON_USING_FAMILY = 0x03
 export const REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS = 0x04
+export const REFERENCE_ICON_USING_7X_GRAPHITE_ICONS = 0x05

--- a/src/components/__fixtures__/helpers.js
+++ b/src/components/__fixtures__/helpers.js
@@ -26,6 +26,10 @@ export function coreHasFeature(feature) {
   if (feature === REFERENCE_ICON_USING_7X_GRAPHITE_ICONS) {
     return coreMajorVersion === 7 && coreMinorVersion >= 2
   }
+
+  if (feature === ICON_TITLE_PROP) {
+    return coreMajorVersion < 7
+  }
 }
 
 export const REFERENCE_ICON_BY_STYLE = 0x00
@@ -34,3 +38,4 @@ export const REFERENCE_ICON_USING_STRING = 0x02
 export const REFERENCE_ICON_USING_FAMILY = 0x03
 export const REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS = 0x04
 export const REFERENCE_ICON_USING_7X_GRAPHITE_ICONS = 0x05
+export const ICON_TITLE_PROP = 0x06

--- a/src/components/__fixtures__/helpers.js
+++ b/src/components/__fixtures__/helpers.js
@@ -37,6 +37,8 @@ export function coreHasFeature(feature) {
   if (feature === ICON_TITLE_PROP) {
     return coreMajorVersion < 7
   }
+
+  return false
 }
 
 export const REFERENCE_ICON_BY_STYLE = 0x00

--- a/src/components/__fixtures__/icons.js
+++ b/src/components/__fixtures__/icons.js
@@ -40,6 +40,12 @@ export const faFish = {
   icon: [640, 512, [], 'f578', '...']
 }
 
+export const faDogUtility = {
+  prefix: 'faufsb',
+  iconName: 'dog',
+  icon: [640, 512, [], 'f6d4', '...']
+}
+
 export const faDogGraphite = {
   prefix: 'fagt',
   iconName: 'dog',

--- a/src/components/__fixtures__/icons.js
+++ b/src/components/__fixtures__/icons.js
@@ -39,15 +39,3 @@ export const faFish = {
   iconName: 'fish',
   icon: [640, 512, [], 'f578', '...']
 }
-
-export const faDogUtility = {
-  prefix: 'faufsb',
-  iconName: 'dog',
-  icon: [640, 512, [], 'f6d4', '...']
-}
-
-export const faDogGraphite = {
-  prefix: 'fagt',
-  iconName: 'dog',
-  icon: [640, 512, [], 'f6d3', '...']
-}

--- a/src/components/__fixtures__/icons.js
+++ b/src/components/__fixtures__/icons.js
@@ -39,3 +39,9 @@ export const faFish = {
   iconName: 'fish',
   icon: [640, 512, [], 'f578', '...']
 }
+
+export const faDogGraphite = {
+  prefix: 'fagt',
+  iconName: 'dog',
+  icon: [640, 512, [], 'f6d3', '...']
+}

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -211,16 +211,24 @@ describe('unrelated Vue data options', () => {
   })
 })
 
-describe('boolean props apply the correct CSS class', () => {
+describe('display props', () => {
   test.each([
     ['border', 'fa-border'],
     ['listItem', 'fa-li'],
-    ['pulse', 'fa-pulse'],
-    ['swapOpacity', 'fa-swap-opacity'],
     ['fixedWidth', 'fa-fw'],
     ['widthAuto', 'fa-width-auto'],
-    ['spin', 'fa-spin'],
     ['inverse', 'fa-inverse'],
+    ['swapOpacity', 'fa-swap-opacity'],
+  ])('using %s', (prop, cls) => {
+    const wrapper = mountFromProps({ icon: faCoffee, [prop]: true })
+    expect(wrapper.element.classList.contains(cls)).toBeTruthy()
+  })
+})
+
+describe('animation props', () => {
+  test.each([
+    ['spin', 'fa-spin'],
+    ['pulse', 'fa-pulse'],
     ['bounce', 'fa-bounce'],
     ['shake', 'fa-shake'],
     ['beat', 'fa-beat'],

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -1,22 +1,23 @@
 import { faClose, faUser } from '@fortawesome/free-solid-svg-icons'
-import { faAlien, faBat, faCat, faCircle, faCoffee, faDog, faDogGraphite, faFish } from '../__fixtures__/icons'
+import { faAlien, faBat, faCat, faCircle, faCoffee, faDog, faDogGraphite, faDogUtility, faFish } from '../__fixtures__/icons'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   compileAndMount,
   mountFromProps,
-  SUPPORTS_ICON_BY_STYLE,
-  SUPPORTS_ICON_ALIASES,
-  SUPPORTS_ICON_USING_STRING,
-  SUPPORTS_ICON_USING_FAMILY,
-  SUPPORTS_7X_SMALL_BATCH_ICONS,
   SUPPORTS_7X_GRAPHITE_ICONS,
+  SUPPORTS_7X_SMALL_BATCH_ICONS,
+  SUPPORTS_7X_UTILITY_ICONS,
+  SUPPORTS_ICON_ALIASES,
+  SUPPORTS_ICON_BY_STYLE,
+  SUPPORTS_ICON_USING_FAMILY,
+  SUPPORTS_ICON_USING_STRING,
   SUPPORTS_TITLE_PROP
 } from '../__fixtures__/helpers'
 
 import FontAwesomeIcon from '../FontAwesomeIcon'
 
 beforeEach(() => {
-  library.add(faAlien, faBat, faCat, faCircle, faCoffee, faDog, faDogGraphite, faFish)
+  library.add(faAlien, faBat, faCat, faCircle, faCoffee, faDog, faDogGraphite, faDogUtility, faFish)
 })
 
 afterEach(() => {
@@ -622,7 +623,20 @@ describe('using a family', () => {
     })
   }
 
-  if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_SMALL_BATCH_ICONS && SUPPORTS_7X_GRAPHITE_ICONS) {
+  if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_UTILITY_ICONS) {
+    test('will find a utility fill-semibold icon using string format, long prefix, and long fa-icon name', () => {
+      const wrapper = mountFromProps({ icon: 'fa-utility fa-fill-semibold fa-dog' })
+
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
+    })
+  } else if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_SMALL_BATCH_ICONS) {
+    test('7x utility icons are not supported in this core version', () => {
+      expect(SUPPORTS_7X_UTILITY_ICONS).toBeFalsy()
+    })
+  }
+
+  if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_GRAPHITE_ICONS) {
     test('will default to a graphite thin icon using string format, long prefix, and long fa-icon name', () => {
       const wrapper = mountFromProps({ icon: 'fa-graphite fa-dog' })
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -46,6 +46,17 @@ describe('icon title prop', () => {
       expect(titleEl.textContent).toBe('Coffee Icon')
       expect(wrapper.element.getAttribute('aria-labelledby')).toContain('coffee-title')
     })
+
+    test('renders a title element without titleId', () => {
+      const wrapper = mountFromProps({
+        icon: faCoffee,
+        title: 'Coffee Icon'
+      })
+
+      const titleEl = wrapper.element.querySelector('title')
+      expect(titleEl).toBeTruthy()
+      expect(titleEl.textContent).toBe('Coffee Icon')
+    })
   } else {
     test('ICON_TITLE_PROP is not available in this core version', () => {
       expect(coreHasFeature(ICON_TITLE_PROP)).toBeFalsy()
@@ -432,6 +443,47 @@ describe('reactivity', () => {
     await wrapper.setProps({ icon: faCircle, title: 'Circle' })
 
     expect(wrapper.element.classList.contains('fa-circle')).toBeTruthy()
+  })
+
+  test('adding gradientFill updates the element', async () => {
+    const wrapper = mountFromProps({ icon: faCoffee })
+
+    expect(wrapper.element.querySelector('linearGradient')).toBeNull()
+
+    await wrapper.setProps({
+      gradientFill: {
+        id: 'reactiveGradient',
+        type: 'linear',
+        stops: [
+          { offset: '0%', color: 'red' },
+          { offset: '100%', color: 'blue' }
+        ]
+      }
+    })
+
+    expect(wrapper.element.querySelector('linearGradient')).toBeTruthy()
+    expect(wrapper.element.getAttribute('fill')).toBe('url(#reactiveGradient)')
+  })
+
+  test('removing gradientFill updates the element', async () => {
+    const wrapper = mountFromProps({
+      icon: faCoffee,
+      gradientFill: {
+        id: 'reactiveGradient',
+        type: 'linear',
+        stops: [
+          { offset: '0%', color: 'red' },
+          { offset: '100%', color: 'blue' }
+        ]
+      }
+    })
+
+    expect(wrapper.element.querySelector('linearGradient')).toBeTruthy()
+
+    await wrapper.setProps({ gradientFill: null })
+
+    expect(wrapper.element.querySelector('linearGradient')).toBeNull()
+    expect(wrapper.element.getAttribute('fill')).toBeNull()
   })
 })
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -404,7 +404,7 @@ describe('mask', () => {
   test('will add icon', () => {
     const wrapper = mountFromProps({ icon: faCoffee, mask: faCircle })
 
-    expect(wrapper.element.innerHTML).toMatch(/clipPath/)
+    expect(wrapper.element.querySelector('clipPath')).toBeTruthy()
   })
 
   test('will use maskId for clipPath and mask ids', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -665,7 +665,9 @@ describe('gradientFill prop', () => {
     expect(gradient).toBeTruthy()
     expect(gradient.getAttribute('id')).toBe('myLinearGradient')
     expect(gradient.getAttribute('x1')).toBe('0%')
+    expect(gradient.getAttribute('y1')).toBe('0%')
     expect(gradient.getAttribute('x2')).toBe('100%')
+    expect(gradient.getAttribute('y2')).toBe('0%')
 
     const stops = gradient.querySelectorAll('stop')
 
@@ -699,11 +701,41 @@ describe('gradientFill prop', () => {
 
     expect(gradient).toBeTruthy()
     expect(gradient.getAttribute('id')).toBe('myRadialGradient')
+    expect(gradient.getAttribute('r')).toBe('150%')
+    expect(gradient.getAttribute('cx')).toBe('30%')
+    expect(gradient.getAttribute('cy')).toBe('107%')
+    expect(gradient.getAttribute('fx')).toBeNull()
+    expect(gradient.getAttribute('fy')).toBeNull()
 
     const stops = gradient.querySelectorAll('stop')
 
     expect(stops.length).toBe(3)
     expect(stops[1].getAttribute('stop-opacity')).toBe('0.8')
+  })
+
+  test('applies a radialGradient with optional fx and fy focal point attributes', () => {
+    const wrapper = mountFromProps({
+      icon: faCoffee,
+      gradientFill: {
+        id: 'myRadialGradientFocal',
+        type: 'radial',
+        r: '150%',
+        cx: '30%',
+        cy: '107%',
+        fx: '50%',
+        fy: '50%',
+        stops: [
+          { offset: '0', color: '#FDF497' },
+          { offset: '1', color: '#285AEB' }
+        ]
+      }
+    })
+
+    const gradient = wrapper.element.querySelector('radialGradient')
+
+    expect(gradient).toBeTruthy()
+    expect(gradient.getAttribute('fx')).toBe('50%')
+    expect(gradient.getAttribute('fy')).toBe('50%')
   })
 
   test('strips fill from child path elements when gradientFill is provided', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -347,6 +347,12 @@ test('using size', () => {
   })
 })
 
+test('using fixedWidth', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, fixedWidth: true })
+
+  expect(wrapper.element.classList.contains('fa-fw')).toBeTruthy()
+})
+
 test('using widthAuto', () => {
   const wrapper = mountFromProps({ icon: faCoffee, widthAuto: true })
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -451,68 +451,52 @@ describe('reactivity', () => {
   })
 })
 
-describe('using bounce', () => {
-  test('bounce', () => {
-    const wrapper = mountFromProps({ icon: faCoffee, bounce: true })
+test('using bounce', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, bounce: true })
 
-    expect(wrapper.element.classList.contains('fa-bounce')).toBeTruthy()
-  })
+  expect(wrapper.element.classList.contains('fa-bounce')).toBeTruthy()
 })
 
-describe('using shake', () => {
-  test('shake', () => {
-    const wrapper = mountFromProps({ icon: faCoffee, shake: true })
+test('using shake', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, shake: true })
 
-    expect(wrapper.element.classList.contains('fa-shake')).toBeTruthy()
-  })
+  expect(wrapper.element.classList.contains('fa-shake')).toBeTruthy()
 })
 
-describe('using beat', () => {
-  test('beat', () => {
-    const wrapper = mountFromProps({ icon: faCoffee, beat: true })
+test('using beat', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, beat: true })
 
-    expect(wrapper.element.classList.contains('fa-beat')).toBeTruthy()
-  })
+  expect(wrapper.element.classList.contains('fa-beat')).toBeTruthy()
 })
 
-describe('using fade', () => {
-  test('fade', () => {
-    const wrapper = mountFromProps({ icon: faCoffee, fade: true })
+test('using fade', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, fade: true })
 
-    expect(wrapper.element.classList.contains('fa-fade')).toBeTruthy()
-  })
+  expect(wrapper.element.classList.contains('fa-fade')).toBeTruthy()
 })
 
-describe('using beat-fade', () => {
-  test('beat-fade', () => {
-    const wrapper = mountFromProps({ icon: faCoffee, beatFade: true })
+test('using beat-fade', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, beatFade: true })
 
-    expect(wrapper.element.classList.contains('fa-beat-fade')).toBeTruthy()
-  })
+  expect(wrapper.element.classList.contains('fa-beat-fade')).toBeTruthy()
 })
 
-describe('using flash', () => {
-  test('flash', () => {
-    const wrapper = mountFromProps({ icon: faCoffee, flash: true })
+test('using flash', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, flash: true })
 
-    expect(wrapper.element.classList.contains('fa-flash')).toBeTruthy()
-  })
+  expect(wrapper.element.classList.contains('fa-flash')).toBeTruthy()
 })
 
-describe('using spin-pulse', () => {
-  test('spin-pulse', () => {
-    const wrapper = mountFromProps({ icon: faCoffee, spinPulse: true })
+test('using spin-pulse', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, spinPulse: true })
 
-    expect(wrapper.element.classList.contains('fa-spin-pulse')).toBeTruthy()
-  })
+  expect(wrapper.element.classList.contains('fa-spin-pulse')).toBeTruthy()
 })
 
-describe('using spin-reverse', () => {
-  test('spin-reverse', () => {
-    const wrapper = mountFromProps({ icon: faCoffee, spinReverse: true })
+test('using spin-reverse', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, spinReverse: true })
 
-    expect(wrapper.element.classList.contains('fa-spin-reverse')).toBeTruthy()
-  })
+  expect(wrapper.element.classList.contains('fa-spin-reverse')).toBeTruthy()
 })
 
 test('using imported object from svg icons package', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -1,5 +1,5 @@
 import { faClose, faUser } from '@fortawesome/free-solid-svg-icons'
-import { faAlien, faBat, faCat, faCircle, faCoffee, faDog, faFish } from '../__fixtures__/icons'
+import { faAlien, faBat, faCat, faCircle, faCoffee, faDog, faDogGraphite, faFish } from '../__fixtures__/icons'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   compileAndMount,
@@ -16,7 +16,7 @@ import {
 import FontAwesomeIcon from '../FontAwesomeIcon'
 
 beforeEach(() => {
-  library.add(faAlien, faBat, faCat, faCircle, faCoffee, faDog, faFish)
+  library.add(faAlien, faBat, faCat, faCircle, faCoffee, faDog, faDogGraphite, faFish)
 })
 
 afterEach(() => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -506,22 +506,25 @@ test('using imported object from svg icons package', () => {
 })
 
 if (SUPPORTS_ICON_ALIASES) {
-  test('find a free-solid-svg-icon with array format', () => {
-    library.reset()
-    library.add(faClose)
-    const wrapper = mountFromProps({ icon: ['fas', 'xmark'] })
+  describe('icon aliases', () => {
+    beforeEach(() => {
+      library.reset()
+      library.add(faClose)
+    })
 
-    expect(wrapper.element.tagName).toBe('svg')
-    expect(wrapper.element.classList.contains('fa-xmark')).toBeTruthy()
-  })
+    test('find a free-solid-svg-icon with array format', () => {
+      const wrapper = mountFromProps({ icon: ['fas', 'xmark'] })
 
-  test('find a free-solid-svg-icon that is an alias', () => {
-    library.reset()
-    library.add(faClose)
-    const wrapper = mountFromProps({ icon: ['fas', 'close'] })
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-xmark')).toBeTruthy()
+    })
 
-    expect(wrapper.element.tagName).toBe('svg')
-    expect(wrapper.element.classList.contains('fa-xmark')).toBeTruthy()
+    test('find a free-solid-svg-icon that is an alias', () => {
+      const wrapper = mountFromProps({ icon: ['fas', 'close'] })
+
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-xmark')).toBeTruthy()
+    })
   })
 } else {
   test('icon aliases are not supported in this core version', () => {
@@ -579,68 +582,73 @@ describe('using a family', () => {
       expect(wrapper.element.tagName).toBe('svg')
       expect(wrapper.element.classList.contains('fa-bat')).toBeTruthy()
     })
-
-    if (SUPPORTS_7X_SMALL_BATCH_ICONS) {
-      test('will default to a jelly-duo regular icon using string format, long prefix, and long fa-icon name', () => {
-        const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-cat' })
-
-        expect(wrapper.element.tagName).toBe('svg')
-        expect(wrapper.element.classList.contains('fa-cat')).toBeTruthy()
-      })
-
-      test('will find a jelly-duo regular icon using string format, long prefix, long style, and long fa-icon name', () => {
-        const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-regular fa-cat' })
-
-        expect(wrapper.element.tagName).toBe('svg')
-        expect(wrapper.element.classList.contains('fa-cat')).toBeTruthy()
-      })
-
-      test('will default to a whiteboard semibold icon using string format, long prefix, and long fa-icon name', () => {
-        const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-fish' })
-
-        expect(wrapper.element.tagName).toBe('svg')
-        expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
-      })
-
-      test('will find a whiteboard semibold icon using string format, long prefix, long style, and long fa-icon name', () => {
-        const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-semibold fa-fish' })
-
-        expect(wrapper.element.tagName).toBe('svg')
-        expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
-      })
-
-      if (SUPPORTS_7X_GRAPHITE_ICONS) {
-        test('will default to a graphite thin icon using string format, long prefix, and long fa-icon name', () => {
-          const wrapper = mountFromProps({ icon: 'fa-graphite fa-dog' })
-
-          expect(wrapper.element.tagName).toBe('svg')
-          expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
-        })
-
-        test('will find a graphite thin icon using string format, long prefix, long style, and long fa-icon name', () => {
-          const wrapper = mountFromProps({ icon: 'fa-graphite fa-thin fa-dog' })
-
-          expect(wrapper.element.tagName).toBe('svg')
-          expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
-        })
-      } else {
-        test('7x graphite icons are not supported in this core version', () => {
-          expect(SUPPORTS_7X_GRAPHITE_ICONS).toBeFalsy()
-        })
-      }
-    } else {
-      test('7x small batch icons are not supported in this core version', () => {
-        expect(SUPPORTS_7X_SMALL_BATCH_ICONS).toBeFalsy()
-      })
-    }
   } else {
     test('family icon reference is not supported in this core version', () => {
       expect(SUPPORTS_ICON_USING_FAMILY).toBeFalsy()
     })
   }
+
+  if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_SMALL_BATCH_ICONS) {
+    test('will default to a jelly-duo regular icon using string format, long prefix, and long fa-icon name', () => {
+      const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-cat' })
+
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-cat')).toBeTruthy()
+    })
+
+    test('will find a jelly-duo regular icon using string format, long prefix, long style, and long fa-icon name', () => {
+      const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-regular fa-cat' })
+
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-cat')).toBeTruthy()
+    })
+
+    test('will default to a whiteboard semibold icon using string format, long prefix, and long fa-icon name', () => {
+      const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-fish' })
+
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
+    })
+
+    test('will find a whiteboard semibold icon using string format, long prefix, long style, and long fa-icon name', () => {
+      const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-semibold fa-fish' })
+
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
+    })
+  } else if (SUPPORTS_ICON_USING_FAMILY) {
+    test('7x small batch icons are not supported in this core version', () => {
+      expect(SUPPORTS_7X_SMALL_BATCH_ICONS).toBeFalsy()
+    })
+  }
+
+  if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_SMALL_BATCH_ICONS && SUPPORTS_7X_GRAPHITE_ICONS) {
+    test('will default to a graphite thin icon using string format, long prefix, and long fa-icon name', () => {
+      const wrapper = mountFromProps({ icon: 'fa-graphite fa-dog' })
+
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
+    })
+
+    test('will find a graphite thin icon using string format, long prefix, long style, and long fa-icon name', () => {
+      const wrapper = mountFromProps({ icon: 'fa-graphite fa-thin fa-dog' })
+
+      expect(wrapper.element.tagName).toBe('svg')
+      expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
+    })
+  } else if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_SMALL_BATCH_ICONS) {
+    test('7x graphite icons are not supported in this core version', () => {
+      expect(SUPPORTS_7X_GRAPHITE_ICONS).toBeFalsy()
+    })
+  }
 })
 
 describe('gradientFill prop', () => {
+  const SAMPLE_LINEAR_STOPS = [
+    { offset: '0%', color: '#FF5F6D' },
+    { offset: '100%', color: '#FFC371' }
+  ]
+
   test('applies a linearGradient element and fill reference to svg', () => {
     const wrapper = mountFromProps({
       icon: faCoffee,
@@ -651,10 +659,7 @@ describe('gradientFill prop', () => {
         y1: '0%',
         x2: '100%',
         y2: '0%',
-        stops: [
-          { offset: '0%', color: '#FF5F6D' },
-          { offset: '100%', color: '#FFC371' }
-        ]
+        stops: SAMPLE_LINEAR_STOPS
       }
     })
 
@@ -771,10 +776,7 @@ describe('gradientFill prop', () => {
       gradientFill: {
         id: 'arrayGradient',
         type: 'linear',
-        stops: [
-          { offset: '0%', color: '#FF5F6D' },
-          { offset: '100%', color: '#FFC371' }
-        ]
+        stops: SAMPLE_LINEAR_STOPS
       }
     })
 
@@ -788,10 +790,7 @@ describe('gradientFill prop', () => {
       gradientFill: {
         id: 'stringGradient',
         type: 'linear',
-        stops: [
-          { offset: '0%', color: '#FF5F6D' },
-          { offset: '100%', color: '#FFC371' }
-        ]
+        stops: SAMPLE_LINEAR_STOPS
       }
     })
 
@@ -808,10 +807,7 @@ describe('gradientFill prop', () => {
       gradientFill: {
         id: 'symbolGradient',
         type: 'linear',
-        stops: [
-          { offset: '0%', color: '#FF5F6D' },
-          { offset: '100%', color: '#FFC371' }
-        ]
+        stops: SAMPLE_LINEAR_STOPS
       }
     })
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -326,7 +326,7 @@ describe('using rotateBy', () => {
     expect(wrapper.element.classList.contains('fa-rotate-by')).toBeTruthy()
   })
 
-  test('not using rotateBy shows will not show the fa-rotate-by class', () => {
+  test('not using rotateBy will not show the fa-rotate-by class', () => {
     const wrapper = mountFromProps({ icon: faDog })
 
     expect(wrapper.element.classList.contains('fa-rotate-by')).toBeFalsy()

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -1,23 +1,22 @@
 import { faClose, faUser } from '@fortawesome/free-solid-svg-icons'
-import { faAlien, faBat, faCat, faCircle, faCoffee, faDog, faDogGraphite, faDogUtility, faFish } from '../__fixtures__/icons'
+import { faAlien, faBat, faCat, faCircle, faCoffee, faDog, faFish } from '../__fixtures__/icons'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   compileAndMount,
   mountFromProps,
-  SUPPORTS_7X_GRAPHITE_ICONS,
-  SUPPORTS_7X_SMALL_BATCH_ICONS,
-  SUPPORTS_7X_UTILITY_ICONS,
-  SUPPORTS_ICON_ALIASES,
-  SUPPORTS_ICON_BY_STYLE,
-  SUPPORTS_ICON_USING_FAMILY,
-  SUPPORTS_ICON_USING_STRING,
-  SUPPORTS_TITLE_PROP
+  coreHasFeature,
+  REFERENCE_ICON_BY_STYLE,
+  REFERENCE_ICON_USING_STRING,
+  REFERENCE_ICON_USING_FAMILY,
+  REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS,
+  ICON_ALIASES,
+  ICON_TITLE_PROP
 } from '../__fixtures__/helpers'
 
 import FontAwesomeIcon from '../FontAwesomeIcon'
 
 beforeEach(() => {
-  library.add(faAlien, faBat, faCat, faCircle, faCoffee, faDog, faDogGraphite, faDogUtility, faFish)
+  library.add(faAlien, faBat, faCat, faCircle, faCoffee, faDog, faFish)
 })
 
 afterEach(() => {
@@ -34,7 +33,7 @@ describe('icon title prop', () => {
     expect(wrapper.element.querySelector('title')).toBeFalsy()
   })
 
-  if (SUPPORTS_TITLE_PROP) {
+  if (coreHasFeature(ICON_TITLE_PROP)) {
     test('renders a title element and aria-labelledby when title is set', () => {
       const wrapper = mountFromProps({
         icon: faCoffee,
@@ -48,8 +47,8 @@ describe('icon title prop', () => {
       expect(wrapper.element.getAttribute('aria-labelledby')).toContain('coffee-title')
     })
   } else {
-    test('title prop is not supported in this core version', () => {
-      expect(SUPPORTS_TITLE_PROP).toBeFalsy()
+    test('ICON_TITLE_PROP is not available in this core version', () => {
+      expect(coreHasFeature(ICON_TITLE_PROP)).toBeFalsy()
     })
   }
 })
@@ -62,7 +61,7 @@ describe('icons are showing', () => {
     expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
   })
 
-  if (SUPPORTS_ICON_BY_STYLE) {
+  if (coreHasFeature(REFERENCE_ICON_BY_STYLE)) {
     test('using array format, short prefix and long icon name', () => {
       const wrapper = mountFromProps({ icon: ['fas', 'fa-coffee'] })
 
@@ -84,12 +83,12 @@ describe('icons are showing', () => {
       expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
     })
   } else {
-    test('icon by style is not supported in this core version', () => {
-      expect(SUPPORTS_ICON_BY_STYLE).toBeFalsy()
+    test('REFERENCE_ICON_BY_STYLE is not available in this core version', () => {
+      expect(coreHasFeature(REFERENCE_ICON_BY_STYLE)).toBeFalsy()
     })
   }
 
-  if (SUPPORTS_ICON_USING_STRING) {
+  if (coreHasFeature(REFERENCE_ICON_USING_STRING)) {
     test('using string format, with long prefix and long icon name', () => {
       const wrapper = mountFromProps({ icon: 'fa-duotone fa-alien' })
 
@@ -104,8 +103,8 @@ describe('icons are showing', () => {
       expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
     })
   } else {
-    test('string icon reference is not supported in this core version', () => {
-      expect(SUPPORTS_ICON_USING_STRING).toBeFalsy()
+    test('REFERENCE_ICON_USING_STRING is not available in this core version', () => {
+      expect(coreHasFeature(REFERENCE_ICON_USING_STRING)).toBeFalsy()
     })
   }
 
@@ -506,7 +505,7 @@ test('using imported object from svg icons package', () => {
   expect(wrapper.element.classList.contains('fa-user')).toBeTruthy()
 })
 
-if (SUPPORTS_ICON_ALIASES) {
+if (coreHasFeature(ICON_ALIASES)) {
   describe('icon aliases', () => {
     beforeEach(() => {
       library.reset()
@@ -528,13 +527,13 @@ if (SUPPORTS_ICON_ALIASES) {
     })
   })
 } else {
-  test('icon aliases are not supported in this core version', () => {
-    expect(SUPPORTS_ICON_ALIASES).toBeFalsy()
+  test('ICON_ALIASES is not available in this core version', () => {
+    expect(coreHasFeature(ICON_ALIASES)).toBeFalsy()
   })
 }
 
 describe('using a family', () => {
-  if (SUPPORTS_ICON_USING_FAMILY) {
+  if (coreHasFeature(REFERENCE_ICON_USING_FAMILY)) {
     test('will find a sharp solid icon using array format, short prefix, and short icon name', () => {
       const wrapper = mountFromProps({ icon: ['fass', 'dog'] })
 
@@ -583,76 +582,43 @@ describe('using a family', () => {
       expect(wrapper.element.tagName).toBe('svg')
       expect(wrapper.element.classList.contains('fa-bat')).toBeTruthy()
     })
+
+    if (coreHasFeature(REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS)) {
+      test('will default to a jelly-duo regular icon using string format, long prefix, and long fa-icon name', () => {
+        const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-cat' })
+
+        expect(wrapper.element.tagName).toBe('svg')
+        expect(wrapper.element.classList.contains('fa-cat')).toBeTruthy()
+      })
+
+      test('will find a jelly-duo regular icon using string format, long prefix, long style, and long fa-icon name', () => {
+        const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-regular fa-cat' })
+
+        expect(wrapper.element.tagName).toBe('svg')
+        expect(wrapper.element.classList.contains('fa-cat')).toBeTruthy()
+      })
+
+      test('will default to a whiteboard semibold icon using string format, long prefix, and long fa-icon name', () => {
+        const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-fish' })
+
+        expect(wrapper.element.tagName).toBe('svg')
+        expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
+      })
+
+      test('will find a whiteboard semibold icon using string format, long prefix, long style, and long fa-icon name', () => {
+        const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-semibold fa-fish' })
+
+        expect(wrapper.element.tagName).toBe('svg')
+        expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
+      })
+    } else {
+      test('REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS is not available in this core version', () => {
+        expect(coreHasFeature(REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS)).toBeFalsy()
+      })
+    }
   } else {
-    test('family icon reference is not supported in this core version', () => {
-      expect(SUPPORTS_ICON_USING_FAMILY).toBeFalsy()
-    })
-  }
-
-  if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_SMALL_BATCH_ICONS) {
-    test('will default to a jelly-duo regular icon using string format, long prefix, and long fa-icon name', () => {
-      const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-cat' })
-
-      expect(wrapper.element.tagName).toBe('svg')
-      expect(wrapper.element.classList.contains('fa-cat')).toBeTruthy()
-    })
-
-    test('will find a jelly-duo regular icon using string format, long prefix, long style, and long fa-icon name', () => {
-      const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-regular fa-cat' })
-
-      expect(wrapper.element.tagName).toBe('svg')
-      expect(wrapper.element.classList.contains('fa-cat')).toBeTruthy()
-    })
-
-    test('will default to a whiteboard semibold icon using string format, long prefix, and long fa-icon name', () => {
-      const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-fish' })
-
-      expect(wrapper.element.tagName).toBe('svg')
-      expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
-    })
-
-    test('will find a whiteboard semibold icon using string format, long prefix, long style, and long fa-icon name', () => {
-      const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-semibold fa-fish' })
-
-      expect(wrapper.element.tagName).toBe('svg')
-      expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
-    })
-  } else if (SUPPORTS_ICON_USING_FAMILY) {
-    test('7x small batch icons are not supported in this core version', () => {
-      expect(SUPPORTS_7X_SMALL_BATCH_ICONS).toBeFalsy()
-    })
-  }
-
-  if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_UTILITY_ICONS) {
-    test('will find a utility fill-semibold icon using string format, long prefix, and long fa-icon name', () => {
-      const wrapper = mountFromProps({ icon: 'fa-utility fa-fill-semibold fa-dog' })
-
-      expect(wrapper.element.tagName).toBe('svg')
-      expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
-    })
-  } else if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_SMALL_BATCH_ICONS) {
-    test('7x utility icons are not supported in this core version', () => {
-      expect(SUPPORTS_7X_UTILITY_ICONS).toBeFalsy()
-    })
-  }
-
-  if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_GRAPHITE_ICONS) {
-    test('will default to a graphite thin icon using string format, long prefix, and long fa-icon name', () => {
-      const wrapper = mountFromProps({ icon: 'fa-graphite fa-dog' })
-
-      expect(wrapper.element.tagName).toBe('svg')
-      expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
-    })
-
-    test('will find a graphite thin icon using string format, long prefix, long style, and long fa-icon name', () => {
-      const wrapper = mountFromProps({ icon: 'fa-graphite fa-thin fa-dog' })
-
-      expect(wrapper.element.tagName).toBe('svg')
-      expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
-    })
-  } else if (SUPPORTS_ICON_USING_FAMILY && SUPPORTS_7X_SMALL_BATCH_ICONS) {
-    test('7x graphite icons are not supported in this core version', () => {
-      expect(SUPPORTS_7X_GRAPHITE_ICONS).toBeFalsy()
+    test('REFERENCE_ICON_USING_FAMILY is not available in this core version', () => {
+      expect(coreHasFeature(REFERENCE_ICON_USING_FAMILY)).toBeFalsy()
     })
   }
 })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -4,14 +4,13 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   compileAndMount,
   mountFromProps,
-  coreHasFeature,
-  REFERENCE_ICON_USING_STRING,
-  REFERENCE_ICON_BY_STYLE,
-  REFERENCE_ICON_USING_FAMILY,
-  REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS,
-  REFERENCE_ICON_USING_7X_GRAPHITE_ICONS,
-  ICON_ALIASES,
-  ICON_TITLE_PROP
+  SUPPORTS_ICON_BY_STYLE,
+  SUPPORTS_ICON_ALIASES,
+  SUPPORTS_ICON_USING_STRING,
+  SUPPORTS_ICON_USING_FAMILY,
+  SUPPORTS_7X_SMALL_BATCH_ICONS,
+  SUPPORTS_7X_GRAPHITE_ICONS,
+  SUPPORTS_TITLE_PROP
 } from '../__fixtures__/helpers'
 
 import FontAwesomeIcon from '../FontAwesomeIcon'
@@ -34,7 +33,7 @@ describe('icon title prop', () => {
     expect(wrapper.element.querySelector('title')).toBeFalsy()
   })
 
-  if (coreHasFeature(ICON_TITLE_PROP)) {
+  if (SUPPORTS_TITLE_PROP) {
     test('renders a title element and aria-labelledby when title is set', () => {
       const wrapper = mountFromProps({
         icon: faCoffee,
@@ -48,8 +47,8 @@ describe('icon title prop', () => {
       expect(wrapper.element.getAttribute('aria-labelledby')).toContain('coffee-title')
     })
   } else {
-    test('ICON_TITLE_PROP is not available in this core version', () => {
-      expect(coreHasFeature(ICON_TITLE_PROP)).toBeFalsy()
+    test('title prop is not supported in this core version', () => {
+      expect(SUPPORTS_TITLE_PROP).toBeFalsy()
     })
   }
 })
@@ -62,7 +61,7 @@ describe('icons are showing', () => {
     expect(wrapper.element.classList.contains('fa-coffee')).toBeTruthy()
   })
 
-  if (coreHasFeature(REFERENCE_ICON_BY_STYLE)) {
+  if (SUPPORTS_ICON_BY_STYLE) {
     test('using array format, short prefix and long icon name', () => {
       const wrapper = mountFromProps({ icon: ['fas', 'fa-coffee'] })
 
@@ -84,12 +83,12 @@ describe('icons are showing', () => {
       expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
     })
   } else {
-    test('REFERENCE_ICON_BY_STYLE is not available in this core version', () => {
-      expect(coreHasFeature(REFERENCE_ICON_BY_STYLE)).toBeFalsy()
+    test('icon by style is not supported in this core version', () => {
+      expect(SUPPORTS_ICON_BY_STYLE).toBeFalsy()
     })
   }
 
-  if (coreHasFeature(REFERENCE_ICON_USING_STRING)) {
+  if (SUPPORTS_ICON_USING_STRING) {
     test('using string format, with long prefix and long icon name', () => {
       const wrapper = mountFromProps({ icon: 'fa-duotone fa-alien' })
 
@@ -104,8 +103,8 @@ describe('icons are showing', () => {
       expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
     })
   } else {
-    test('REFERENCE_ICON_USING_STRING is not available in this core version', () => {
-      expect(coreHasFeature(REFERENCE_ICON_USING_STRING)).toBeFalsy()
+    test('string icon reference is not supported in this core version', () => {
+      expect(SUPPORTS_ICON_USING_STRING).toBeFalsy()
     })
   }
 
@@ -506,7 +505,7 @@ test('using imported object from svg icons package', () => {
   expect(wrapper.element.classList.contains('fa-user')).toBeTruthy()
 })
 
-if (coreHasFeature(ICON_ALIASES)) {
+if (SUPPORTS_ICON_ALIASES) {
   test('find a free-solid-svg-icon with array format', () => {
     library.reset()
     library.add(faClose)
@@ -525,13 +524,13 @@ if (coreHasFeature(ICON_ALIASES)) {
     expect(wrapper.element.classList.contains('fa-xmark')).toBeTruthy()
   })
 } else {
-  test('ICON_ALIASES is not available in this core version', () => {
-    expect(coreHasFeature(ICON_ALIASES)).toBeFalsy()
+  test('icon aliases are not supported in this core version', () => {
+    expect(SUPPORTS_ICON_ALIASES).toBeFalsy()
   })
 }
 
 describe('using a family', () => {
-  if (coreHasFeature(REFERENCE_ICON_USING_FAMILY)) {
+  if (SUPPORTS_ICON_USING_FAMILY) {
     test('will find a sharp solid icon using array format, short prefix, and short icon name', () => {
       const wrapper = mountFromProps({ icon: ['fass', 'dog'] })
 
@@ -581,7 +580,7 @@ describe('using a family', () => {
       expect(wrapper.element.classList.contains('fa-bat')).toBeTruthy()
     })
 
-    if (coreHasFeature(REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS)) {
+    if (SUPPORTS_7X_SMALL_BATCH_ICONS) {
       test('will default to a jelly-duo regular icon using string format, long prefix, and long fa-icon name', () => {
         const wrapper = mountFromProps({ icon: 'fa-jelly-duo fa-cat' })
 
@@ -610,7 +609,7 @@ describe('using a family', () => {
         expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
       })
 
-      if (coreHasFeature(REFERENCE_ICON_USING_7X_GRAPHITE_ICONS)) {
+      if (SUPPORTS_7X_GRAPHITE_ICONS) {
         test('will default to a graphite thin icon using string format, long prefix, and long fa-icon name', () => {
           const wrapper = mountFromProps({ icon: 'fa-graphite fa-dog' })
 
@@ -625,18 +624,18 @@ describe('using a family', () => {
           expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
         })
       } else {
-        test('REFERENCE_ICON_USING_7X_GRAPHITE_ICONS is not available in this core version', () => {
-          expect(coreHasFeature(REFERENCE_ICON_USING_7X_GRAPHITE_ICONS)).toBeFalsy()
+        test('7x graphite icons are not supported in this core version', () => {
+          expect(SUPPORTS_7X_GRAPHITE_ICONS).toBeFalsy()
         })
       }
     } else {
-      test('REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS is not available in this core version', () => {
-        expect(coreHasFeature(REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS)).toBeFalsy()
+      test('7x small batch icons are not supported in this core version', () => {
+        expect(SUPPORTS_7X_SMALL_BATCH_ICONS).toBeFalsy()
       })
     }
   } else {
-    test('REFERENCE_ICON_USING_FAMILY is not available in this core version', () => {
-      expect(coreHasFeature(REFERENCE_ICON_USING_FAMILY)).toBeFalsy()
+    test('family icon reference is not supported in this core version', () => {
+      expect(SUPPORTS_ICON_USING_FAMILY).toBeFalsy()
     })
   }
 })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -603,8 +603,8 @@ describe('using a family', () => {
         })
       }
     } else {
-      test.skip('icon pack tests (jelly-duo, whiteboard) are only available in 7.x', () => {
-        // Skipped: icon packs not supported in this core version
+      test('REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS is not available in this core version', () => {
+        expect(coreHasFeature(REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS)).toBeFalsy()
       })
     }
   } else {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -10,7 +10,8 @@ import {
   REFERENCE_ICON_USING_FAMILY,
   REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS,
   REFERENCE_ICON_USING_7X_GRAPHITE_ICONS,
-  ICON_ALIASES
+  ICON_ALIASES,
+  ICON_TITLE_PROP
 } from '../__fixtures__/helpers'
 
 import FontAwesomeIcon from '../FontAwesomeIcon'
@@ -32,6 +33,25 @@ describe('icon title prop', () => {
     expect(wrapper.element.getAttribute('aria-labelledby')).toBeFalsy()
     expect(wrapper.element.querySelector('title')).toBeFalsy()
   })
+
+  if (coreHasFeature(ICON_TITLE_PROP)) {
+    test('renders a title element and aria-labelledby when title is set', () => {
+      const wrapper = mountFromProps({
+        icon: faCoffee,
+        title: 'Coffee Icon',
+        titleId: 'coffee-title'
+      })
+
+      const titleEl = wrapper.element.querySelector('title')
+      expect(titleEl).toBeTruthy()
+      expect(titleEl.textContent).toBe('Coffee Icon')
+      expect(wrapper.element.getAttribute('aria-labelledby')).toContain('coffee-title')
+    })
+  } else {
+    test('ICON_TITLE_PROP is not available in this core version', () => {
+      expect(coreHasFeature(ICON_TITLE_PROP)).toBeFalsy()
+    })
+  }
 })
 
 describe('icons are showing', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -497,6 +497,10 @@ if (coreHasFeature(ICON_ALIASES)) {
     expect(wrapper.element.tagName).toBe('svg')
     expect(wrapper.element.classList.contains('fa-xmark')).toBeTruthy()
   })
+} else {
+  test('ICON_ALIASES is not available in this core version', () => {
+    expect(coreHasFeature(ICON_ALIASES)).toBeFalsy()
+  })
 }
 
 describe('using a family', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -756,34 +756,33 @@ describe('gradientFill prop', () => {
     consoleSpy.mockRestore()
   })
 
-  test('warns when gradientFill.id is missing', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  describe('validator warnings', () => {
+    let consoleSpy
 
-    mountFromProps({
-      icon: faCoffee,
-      gradientFill: {
-        type: 'linear',
-        stops: SAMPLE_LINEAR_STOPS
-      }
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     })
 
-    expect(consoleSpy).toHaveBeenCalledWith('FontAwesomeIcon: gradientFill.id must be a non-empty string')
-    consoleSpy.mockRestore()
-  })
-
-  test('warns when gradientFill.type is invalid', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-    mountFromProps({
-      icon: faCoffee,
-      gradientFill: {
-        id: 'myGradient',
-        type: 'diagonal',
-        stops: SAMPLE_LINEAR_STOPS
-      }
+    afterEach(() => {
+      consoleSpy.mockRestore()
     })
 
-    expect(consoleSpy).toHaveBeenCalledWith('FontAwesomeIcon: gradientFill.type must be "linear" or "radial"')
-    consoleSpy.mockRestore()
+    test('warns when gradientFill.id is missing', () => {
+      mountFromProps({
+        icon: faCoffee,
+        gradientFill: { type: 'linear', stops: SAMPLE_LINEAR_STOPS }
+      })
+
+      expect(consoleSpy).toHaveBeenCalledWith('FontAwesomeIcon: gradientFill.id must be a non-empty string')
+    })
+
+    test('warns when gradientFill.type is invalid', () => {
+      mountFromProps({
+        icon: faCoffee,
+        gradientFill: { id: 'myGradient', type: 'diagonal', stops: SAMPLE_LINEAR_STOPS }
+      })
+
+      expect(consoleSpy).toHaveBeenCalledWith('FontAwesomeIcon: gradientFill.type must be "linear" or "radial"')
+    })
   })
 })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -403,11 +403,20 @@ describe('symbol', () => {
     expect(wrapper.element.style.getPropertyValue('display')).toBe('')
   })
 
-  test('will create a symbol', () => {
+  test('will create a symbol with a string id', () => {
     const wrapper = mountFromProps({ icon: faCoffee, symbol: 'coffee-icon' })
 
     expect(wrapper.element.style.getPropertyValue('display')).toBe('none')
     expect(wrapper.element.children[0].tagName).toBe('symbol')
+    expect(wrapper.element.children[0].getAttribute('id')).toBe('coffee-icon')
+  })
+
+  test('will create a symbol with an auto-generated id when symbol is true', () => {
+    const wrapper = mountFromProps({ icon: faCoffee, symbol: true })
+
+    expect(wrapper.element.style.getPropertyValue('display')).toBe('none')
+    expect(wrapper.element.children[0].tagName).toBe('symbol')
+    expect(wrapper.element.children[0].getAttribute('id')).toBe('fas-fa-coffee')
   })
 })
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -783,6 +783,7 @@ describe('gradientFill prop', () => {
       }
     })
 
+    expect(consoleSpy).toHaveBeenCalledWith('gradientFill is not supported when symbol is true and will be ignored')
     expect(wrapper.element.querySelector('linearGradient')).toBeNull()
     const fill = wrapper.element.getAttribute('fill')
     expect(fill === null || !fill.includes('url(')).toBe(true)

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -503,6 +503,7 @@ test('using imported object from svg icons package', () => {
   const wrapper = mountFromProps({ icon: faUser })
 
   expect(wrapper.element.tagName).toBe('svg')
+  expect(wrapper.element.classList.contains('fa-user')).toBeTruthy()
 })
 
 if (coreHasFeature(ICON_ALIASES)) {
@@ -762,7 +763,7 @@ describe('gradientFill prop', () => {
 
     const fill = wrapper.element.getAttribute('fill')
 
-    expect(fill === null || !fill.includes('url(')).toBe(true)
+    expect(fill).toBeNull()
   })
 
   test('works with array icon syntax', () => {
@@ -818,7 +819,7 @@ describe('gradientFill prop', () => {
     expect(consoleSpy).toHaveBeenCalledWith('gradientFill is not supported when symbol is true and will be ignored')
     expect(wrapper.element.querySelector('linearGradient')).toBeNull()
     const fill = wrapper.element.getAttribute('fill')
-    expect(fill === null || !fill.includes('url(')).toBe(true)
+    expect(fill).toBeNull()
     consoleSpy.mockRestore()
   })
 })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -373,8 +373,20 @@ describe('using transform', () => {
 })
 
 describe('mask', () => {
-  test('will add icon', () => {
+  test('will add icon using iconDefinition', () => {
     const wrapper = mountFromProps({ icon: faCoffee, mask: faCircle })
+
+    expect(wrapper.element.querySelector('clipPath')).toBeTruthy()
+  })
+
+  test('will add icon using array format', () => {
+    const wrapper = mountFromProps({ icon: faCoffee, mask: ['fas', 'circle'] })
+
+    expect(wrapper.element.querySelector('clipPath')).toBeTruthy()
+  })
+
+  test('will add icon using string format', () => {
+    const wrapper = mountFromProps({ icon: faCoffee, mask: 'circle' })
 
     expect(wrapper.element.querySelector('clipPath')).toBeTruthy()
   })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -3,6 +3,7 @@ import { faAlien, faBat, faCat, faCircle, faCoffee, faDog, faFish } from '../__f
 import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   compileAndMount,
+  compileWithTemplate,
   coreHasFeature,
   mountFromProps,
   ICON_ALIASES,
@@ -142,58 +143,26 @@ describe('icons are showing', () => {
 
 describe('unrelated Vue data options', () => {
   test('with extra static class', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-icon class="extra" :icon="icon" />',
-      data() {
-        return { icon: faCoffee }
-      },
-      components: {
-        FontAwesomeIcon
-      }
-    })
+    const wrapper = compileWithTemplate('<font-awesome-icon class="extra" :icon="icon" />', faCoffee)
 
     expect(wrapper.element.classList.contains('extra')).toBeTruthy()
   })
 
   test('with extra bound class', () => {
-    const wrapper = compileAndMount({
-      template: `<font-awesome-icon :class="['extra1', {'extra2': true}]" :icon="icon" />`,
-      data() {
-        return { icon: faCoffee }
-      },
-      components: {
-        FontAwesomeIcon
-      }
-    })
+    const wrapper = compileWithTemplate(`<font-awesome-icon :class="['extra1', {'extra2': true}]" :icon="icon" />`, faCoffee)
 
     expect(wrapper.element.classList.contains('extra1')).toBeTruthy()
     expect(wrapper.element.classList.contains('extra2')).toBeTruthy()
   })
 
   test('with extra style', () => {
-    const wrapper = compileAndMount({
-      template: `<font-awesome-icon :style="{'font-size': '42px'}" :icon="icon" />`,
-      data() {
-        return { icon: faCoffee }
-      },
-      components: {
-        FontAwesomeIcon
-      }
-    })
+    const wrapper = compileWithTemplate(`<font-awesome-icon :style="{'font-size': '42px'}" :icon="icon" />`, faCoffee)
 
     expect(wrapper.element.style.getPropertyValue('font-size')).toBe('42px')
   })
 
   test('with extra DOM property', () => {
-    const wrapper = compileAndMount({
-      template: `<font-awesome-icon rel="local" :icon="icon" />`,
-      data() {
-        return { icon: faCoffee }
-      },
-      components: {
-        FontAwesomeIcon
-      }
-    })
+    const wrapper = compileWithTemplate(`<font-awesome-icon rel="local" :icon="icon" />`, faCoffee)
 
     expect(wrapper.element.getAttribute('rel')).toBe('local')
   })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -347,6 +347,12 @@ test('using size', () => {
   })
 })
 
+test('using widthAuto', () => {
+  const wrapper = mountFromProps({ icon: faCoffee, widthAuto: true })
+
+  expect(wrapper.element.classList.contains('fa-width-auto')).toBeTruthy()
+})
+
 test('using spin', () => {
   const wrapper = mountFromProps({ icon: faCoffee, spin: true })
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -406,6 +406,13 @@ describe('mask', () => {
 
     expect(wrapper.element.innerHTML).toMatch(/clipPath/)
   })
+
+  test('will use maskId for clipPath and mask ids', () => {
+    const wrapper = mountFromProps({ icon: faCoffee, mask: faCircle, maskId: 'my-mask' })
+
+    expect(wrapper.element.querySelector('clipPath').getAttribute('id')).toBe('clip-my-mask')
+    expect(wrapper.element.querySelector('mask').getAttribute('id')).toBe('mask-my-mask')
+  })
 })
 
 describe('symbol', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -389,14 +389,6 @@ describe('symbol', () => {
   })
 })
 
-describe('title', () => {
-  test('not using title', () => {
-    const wrapper = mountFromProps({ icon: faCoffee })
-
-    expect(wrapper.element.getElementsByTagName('title').length).toBe(0)
-  })
-})
-
 describe('reactivity', () => {
   test('changing props should update the element', async () => {
     const wrapper = mountFromProps({ icon: faCoffee, title: 'Coffee' })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -346,7 +346,8 @@ describe('using transform', () => {
       transform: 'grow-40 left-4 rotate-15'
     })
 
-    expect(wrapper.element).toBeTruthy()
+    expect(wrapper.element.style.getPropertyValue('transform-origin')).toBeTruthy()
+    expect(wrapper.element.querySelector('g[transform]')).toBeTruthy()
   })
 
   test('object', () => {
@@ -362,7 +363,8 @@ describe('using transform', () => {
       }
     })
 
-    expect(wrapper.element).toBeTruthy()
+    expect(wrapper.element.style.getPropertyValue('transform-origin')).toBeTruthy()
+    expect(wrapper.element.querySelector('g[transform]')).toBeTruthy()
   })
 })
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -9,6 +9,7 @@ import {
   REFERENCE_ICON_BY_STYLE,
   REFERENCE_ICON_USING_FAMILY,
   REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS,
+  REFERENCE_ICON_USING_7X_GRAPHITE_ICONS,
   ICON_ALIASES
 } from '../__fixtures__/helpers'
 
@@ -62,6 +63,10 @@ describe('icons are showing', () => {
       expect(wrapper.element.tagName).toBe('svg')
       expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
     })
+  } else {
+    test('REFERENCE_ICON_BY_STYLE is not available in this core version', () => {
+      expect(coreHasFeature(REFERENCE_ICON_BY_STYLE)).toBeFalsy()
+    })
   }
 
   if (coreHasFeature(REFERENCE_ICON_USING_STRING)) {
@@ -77,6 +82,10 @@ describe('icons are showing', () => {
 
       expect(wrapper.element.tagName).toBe('svg')
       expect(wrapper.element.classList.contains('fa-alien')).toBeTruthy()
+    })
+  } else {
+    test('REFERENCE_ICON_USING_STRING is not available in this core version', () => {
+      expect(coreHasFeature(REFERENCE_ICON_USING_STRING)).toBeFalsy()
     })
   }
 
@@ -304,7 +313,7 @@ describe('using rotateBy', () => {
   })
 })
 
-test('swap opacity', () => {
+test('using swap opacity', () => {
   const wrapper = mountFromProps({ icon: faCoffee, swapOpacity: true })
 
   expect(wrapper.element.classList.contains('fa-swap-opacity')).toBeTruthy()
@@ -563,12 +572,32 @@ describe('using a family', () => {
         expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
       })
 
-      test('will find a jelly-duo regular icon using string format, long prefix, long style, and long fa-icon name', () => {
+      test('will find a whiteboard semibold icon using string format, long prefix, long style, and long fa-icon name', () => {
         const wrapper = mountFromProps({ icon: 'fa-whiteboard fa-semibold fa-fish' })
 
         expect(wrapper.element.tagName).toBe('svg')
         expect(wrapper.element.classList.contains('fa-fish')).toBeTruthy()
       })
+
+      if (coreHasFeature(REFERENCE_ICON_USING_7X_GRAPHITE_ICONS)) {
+        test('will default to a graphite thin icon using string format, long prefix, and long fa-icon name', () => {
+          const wrapper = mountFromProps({ icon: 'fa-graphite fa-dog' })
+
+          expect(wrapper.element.tagName).toBe('svg')
+          expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
+        })
+
+        test('will find a graphite thin icon using string format, long prefix, long style, and long fa-icon name', () => {
+          const wrapper = mountFromProps({ icon: 'fa-graphite fa-thin fa-dog' })
+
+          expect(wrapper.element.tagName).toBe('svg')
+          expect(wrapper.element.classList.contains('fa-dog')).toBeTruthy()
+        })
+      } else {
+        test('REFERENCE_ICON_USING_7X_GRAPHITE_ICONS is not available in this core version', () => {
+          expect(coreHasFeature(REFERENCE_ICON_USING_7X_GRAPHITE_ICONS)).toBeFalsy()
+        })
+      }
     } else {
       test.skip('icon pack tests (jelly-duo, whiteboard) are only available in 7.x', () => {
         // Skipped: icon packs not supported in this core version

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -3,14 +3,14 @@ import { faAlien, faBat, faCat, faCircle, faCoffee, faDog, faFish } from '../__f
 import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   compileAndMount,
-  mountFromProps,
   coreHasFeature,
-  REFERENCE_ICON_BY_STYLE,
-  REFERENCE_ICON_USING_STRING,
-  REFERENCE_ICON_USING_FAMILY,
-  REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS,
+  mountFromProps,
   ICON_ALIASES,
-  ICON_TITLE_PROP
+  ICON_TITLE_PROP,
+  REFERENCE_ICON_BY_STYLE,
+  REFERENCE_ICON_USING_7X_SMALL_BATCH_ICONS,
+  REFERENCE_ICON_USING_FAMILY,
+  REFERENCE_ICON_USING_STRING
 } from '../__fixtures__/helpers'
 
 import FontAwesomeIcon from '../FontAwesomeIcon'
@@ -211,10 +211,28 @@ describe('unrelated Vue data options', () => {
   })
 })
 
-test('using border', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, border: true })
-
-  expect(wrapper.element.classList.contains('fa-border')).toBeTruthy()
+describe('boolean props apply the correct CSS class', () => {
+  test.each([
+    ['border', 'fa-border'],
+    ['listItem', 'fa-li'],
+    ['pulse', 'fa-pulse'],
+    ['swapOpacity', 'fa-swap-opacity'],
+    ['fixedWidth', 'fa-fw'],
+    ['widthAuto', 'fa-width-auto'],
+    ['spin', 'fa-spin'],
+    ['inverse', 'fa-inverse'],
+    ['bounce', 'fa-bounce'],
+    ['shake', 'fa-shake'],
+    ['beat', 'fa-beat'],
+    ['fade', 'fa-fade'],
+    ['beatFade', 'fa-beat-fade'],
+    ['flash', 'fa-flash'],
+    ['spinPulse', 'fa-spin-pulse'],
+    ['spinReverse', 'fa-spin-reverse'],
+  ])('using %s', (prop, cls) => {
+    const wrapper = mountFromProps({ icon: faCoffee, [prop]: true })
+    expect(wrapper.element.classList.contains(cls)).toBeTruthy()
+  })
 })
 
 describe('using flip', () => {
@@ -254,12 +272,6 @@ describe('using flip', () => {
   })
 })
 
-test('using listItem', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, listItem: true })
-
-  expect(wrapper.element.classList.contains('fa-li')).toBeTruthy()
-})
-
 describe('using pull', () => {
   test('right', () => {
     const wrapper = mountFromProps({ icon: faCoffee, pull: 'right' })
@@ -272,12 +284,6 @@ describe('using pull', () => {
 
     expect(wrapper.element.classList.contains('fa-pull-left')).toBeTruthy()
   })
-})
-
-test('using pulse', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, pulse: true })
-
-  expect(wrapper.element.classList.contains('fa-pulse')).toBeTruthy()
 })
 
 describe('using rotation', () => {
@@ -332,42 +338,12 @@ describe('using rotateBy', () => {
   })
 })
 
-test('using swap opacity', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, swapOpacity: true })
-
-  expect(wrapper.element.classList.contains('fa-swap-opacity')).toBeTruthy()
-})
-
 test('using size', () => {
   ;['2xs', 'xs', 'sm', 'lg', 'xl', '2xl', '1x', '2x', '3x', '4x', '5x', '6x', '7x', '8x', '9x', '10x'].forEach((size) => {
     const wrapper = mountFromProps({ icon: faCoffee, size: size })
 
     expect(wrapper.element.classList.contains(`fa-${size}`)).toBeTruthy()
   })
-})
-
-test('using fixedWidth', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, fixedWidth: true })
-
-  expect(wrapper.element.classList.contains('fa-fw')).toBeTruthy()
-})
-
-test('using widthAuto', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, widthAuto: true })
-
-  expect(wrapper.element.classList.contains('fa-width-auto')).toBeTruthy()
-})
-
-test('using spin', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, spin: true })
-
-  expect(wrapper.element.classList.contains('fa-spin')).toBeTruthy()
-})
-
-test('using inverse', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, inverse: true })
-
-  expect(wrapper.element.classList.contains('fa-inverse')).toBeTruthy()
 })
 
 describe('using transform', () => {
@@ -448,54 +424,6 @@ describe('reactivity', () => {
 
     expect(wrapper.element.classList.contains('fa-circle')).toBeTruthy()
   })
-})
-
-test('using bounce', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, bounce: true })
-
-  expect(wrapper.element.classList.contains('fa-bounce')).toBeTruthy()
-})
-
-test('using shake', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, shake: true })
-
-  expect(wrapper.element.classList.contains('fa-shake')).toBeTruthy()
-})
-
-test('using beat', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, beat: true })
-
-  expect(wrapper.element.classList.contains('fa-beat')).toBeTruthy()
-})
-
-test('using fade', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, fade: true })
-
-  expect(wrapper.element.classList.contains('fa-fade')).toBeTruthy()
-})
-
-test('using beat-fade', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, beatFade: true })
-
-  expect(wrapper.element.classList.contains('fa-beat-fade')).toBeTruthy()
-})
-
-test('using flash', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, flash: true })
-
-  expect(wrapper.element.classList.contains('fa-flash')).toBeTruthy()
-})
-
-test('using spin-pulse', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, spinPulse: true })
-
-  expect(wrapper.element.classList.contains('fa-spin-pulse')).toBeTruthy()
-})
-
-test('using spin-reverse', () => {
-  const wrapper = mountFromProps({ icon: faCoffee, spinReverse: true })
-
-  expect(wrapper.element.classList.contains('fa-spin-reverse')).toBeTruthy()
 })
 
 test('using imported object from svg icons package', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -722,4 +722,35 @@ describe('gradientFill prop', () => {
     expect(fill).toBeNull()
     consoleSpy.mockRestore()
   })
+
+  test('warns when gradientFill.id is missing', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mountFromProps({
+      icon: faCoffee,
+      gradientFill: {
+        type: 'linear',
+        stops: SAMPLE_LINEAR_STOPS
+      }
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith('FontAwesomeIcon: gradientFill.id must be a non-empty string')
+    consoleSpy.mockRestore()
+  })
+
+  test('warns when gradientFill.type is invalid', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mountFromProps({
+      icon: faCoffee,
+      gradientFill: {
+        id: 'myGradient',
+        type: 'diagonal',
+        stops: SAMPLE_LINEAR_STOPS
+      }
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith('FontAwesomeIcon: gradientFill.type must be "linear" or "radial"')
+    consoleSpy.mockRestore()
+  })
 })

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -321,25 +321,14 @@ describe('using rotation', () => {
 })
 
 describe('using rotateBy', () => {
-  test('with a style attribute of 1000 will show the fa-rotate-by class', () => {
-    const wrapper = mountFromProps({ icon: faDog, rotateBy: true, style: '--fa-rotate-angle: 1000deg' })
+  test('will add fa-rotate-by class and apply custom angle via style', () => {
+    const wrapper = mountFromProps({ icon: faDog, rotateBy: true, style: '--fa-rotate-angle: 329deg' })
 
     expect(wrapper.element.classList.contains('fa-rotate-by')).toBeTruthy()
+    expect(wrapper.element.style.getPropertyValue('--fa-rotate-angle')).toBe('329deg')
   })
 
-  test('with a style attribute of `something-` will still show the fa-rotate-by class', () => {
-    const wrapper = mountFromProps({ icon: faDog, rotateBy: true, style: '--fa-rotate-angle: something-deg' })
-
-    expect(wrapper.element.classList.contains('fa-rotate-by')).toBeTruthy()
-  })
-
-  test('without a style attribute will still show the fa-rotate-by class', () => {
-    const wrapper = mountFromProps({ icon: faDog, rotateBy: true })
-
-    expect(wrapper.element.classList.contains('fa-rotate-by')).toBeTruthy()
-  })
-
-  test('not using rotateBy will not show the fa-rotate-by class', () => {
+  test('will not add fa-rotate-by class', () => {
     const wrapper = mountFromProps({ icon: faDog })
 
     expect(wrapper.element.classList.contains('fa-rotate-by')).toBeFalsy()

--- a/src/components/__tests__/FontAwesomeLayers.test.js
+++ b/src/components/__tests__/FontAwesomeLayers.test.js
@@ -24,6 +24,7 @@ test('empty layers', () => {
     }
   })
 
+  expect(wrapper.element.tagName).toBe('DIV')
   expect(wrapper.element.children.length).toBe(0)
 })
 

--- a/src/components/__tests__/FontAwesomeLayers.test.js
+++ b/src/components/__tests__/FontAwesomeLayers.test.js
@@ -12,6 +12,10 @@ beforeEach(() => {
   library.add(faCoffee, faCircle)
 })
 
+afterEach(() => {
+  library.reset()
+})
+
 test('empty layers', () => {
   const wrapper = compileAndMount({
     template: '<font-awesome-layers />',
@@ -23,7 +27,7 @@ test('empty layers', () => {
   expect(wrapper.element.children.length).toBe(0)
 })
 
-test('empty layers', () => {
+test('layers with icon elements', () => {
   const wrapper = compileAndMount({
     template: '<font-awesome-layers><i /><i /></font-awesome-layers>',
     components: {
@@ -55,11 +59,12 @@ describe('class handling', () => {
       }
     })
 
-    expect(wrapper.element.getAttribute('class')).toBe('fa-layers extra')
+    expect(wrapper.element.classList.contains('fa-layers')).toBeTruthy()
+    expect(wrapper.element.classList.contains('extra')).toBeTruthy()
   })
 })
 
-describe('reactivity', () => {
+describe('class defaults', () => {
   let wrapper
 
   beforeEach(() => {
@@ -71,6 +76,6 @@ describe('reactivity', () => {
 
   test('should not have fa-fw class', () => {
     expect(wrapper.element.classList.contains('fa-fw')).toBeFalsy()
-    expect(wrapper.element.getAttribute('class')).toBe('fa-layers')
+    expect(wrapper.element.classList.contains('fa-layers')).toBeTruthy()
   })
 })

--- a/src/components/__tests__/FontAwesomeLayers.test.js
+++ b/src/components/__tests__/FontAwesomeLayers.test.js
@@ -1,12 +1,12 @@
-/**
- * @jest-environment jsdom
- */
-
 import { compileAndMount } from '../__fixtures__/helpers'
 import { faCircle, faCoffee } from '../__fixtures__/icons'
 import { library } from '@fortawesome/fontawesome-svg-core'
 
 import FontAwesomeLayers from '../FontAwesomeLayers'
+
+function mountLayers(template) {
+  return compileAndMount({ template, components: { FontAwesomeLayers } })
+}
 
 beforeEach(() => {
   library.add(faCoffee, faCircle)
@@ -17,48 +17,28 @@ afterEach(() => {
 })
 
 test('empty layers', () => {
-  const wrapper = compileAndMount({
-    template: '<font-awesome-layers />',
-    components: {
-      FontAwesomeLayers
-    }
-  })
+  const wrapper = mountLayers('<font-awesome-layers />')
 
   expect(wrapper.element.tagName).toBe('DIV')
   expect(wrapper.element.children.length).toBe(0)
 })
 
 test('layers with icon elements', () => {
-  const wrapper = compileAndMount({
-    template: '<font-awesome-layers><i /><i /></font-awesome-layers>',
-    components: {
-      FontAwesomeLayers
-    }
-  })
+  const wrapper = mountLayers('<font-awesome-layers><i /><i /></font-awesome-layers>')
 
   expect(wrapper.element.children.length).toBe(2)
 })
 
 describe('class handling', () => {
   test('extra static', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers class="extra" />',
-      components: {
-        FontAwesomeLayers
-      }
-    })
+    const wrapper = mountLayers('<font-awesome-layers class="extra" />')
 
     expect(wrapper.element.classList.contains('extra')).toBeTruthy()
     expect(wrapper.element.classList.contains('fa-layers')).toBeTruthy()
   })
 
   test('extra bound', () => {
-    const wrapper = compileAndMount({
-      template: `<font-awesome-layers :class="['extra']" />`,
-      components: {
-        FontAwesomeLayers
-      }
-    })
+    const wrapper = mountLayers(`<font-awesome-layers :class="['extra']" />`)
 
     expect(wrapper.element.classList.contains('fa-layers')).toBeTruthy()
     expect(wrapper.element.classList.contains('extra')).toBeTruthy()
@@ -67,20 +47,14 @@ describe('class handling', () => {
 
 describe('class defaults', () => {
   test('should have fa-layers class and not fa-fw by default', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers />',
-      components: { FontAwesomeLayers }
-    })
+    const wrapper = mountLayers('<font-awesome-layers />')
 
     expect(wrapper.element.classList.contains('fa-layers')).toBeTruthy()
     expect(wrapper.element.classList.contains('fa-fw')).toBeFalsy()
   })
 
   test('should have fa-fw class when fixedWidth is true', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers :fixed-width="true" />',
-      components: { FontAwesomeLayers }
-    })
+    const wrapper = mountLayers('<font-awesome-layers :fixed-width="true" />')
 
     expect(wrapper.element.classList.contains('fa-layers')).toBeTruthy()
     expect(wrapper.element.classList.contains('fa-fw')).toBeTruthy()

--- a/src/components/__tests__/FontAwesomeLayers.test.js
+++ b/src/components/__tests__/FontAwesomeLayers.test.js
@@ -65,17 +65,23 @@ describe('class handling', () => {
 })
 
 describe('class defaults', () => {
-  let wrapper
-
-  beforeEach(() => {
-    wrapper = compileAndMount({
+  test('should have fa-layers class and not fa-fw by default', () => {
+    const wrapper = compileAndMount({
       template: '<font-awesome-layers />',
       components: { FontAwesomeLayers }
     })
+
+    expect(wrapper.element.classList.contains('fa-layers')).toBeTruthy()
+    expect(wrapper.element.classList.contains('fa-fw')).toBeFalsy()
   })
 
-  test('should not have fa-fw class', () => {
-    expect(wrapper.element.classList.contains('fa-fw')).toBeFalsy()
+  test('should have fa-fw class when fixedWidth is true', () => {
+    const wrapper = compileAndMount({
+      template: '<font-awesome-layers :fixed-width="true" />',
+      components: { FontAwesomeLayers }
+    })
+
     expect(wrapper.element.classList.contains('fa-layers')).toBeTruthy()
+    expect(wrapper.element.classList.contains('fa-fw')).toBeTruthy()
   })
 })

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -6,38 +6,27 @@ import { compileAndMount } from '../__fixtures__/helpers'
 import FontAwesomeLayersText from '../FontAwesomeLayersText'
 import { mount } from '@vue/test-utils'
 
+function mountLayersText(template) {
+  return compileAndMount({ template, components: { FontAwesomeLayersText } })
+}
+
 test('empty', () => {
-  const wrapper = compileAndMount({
-    template: '<font-awesome-layers-text />',
-    components: {
-      FontAwesomeLayersText
-    }
-  })
+  const wrapper = mountLayersText('<font-awesome-layers-text />')
 
   expect(wrapper.element.tagName).toBe('SPAN')
-  expect(wrapper.element.classList.contains('fa-layers-text')).toBeTruthy()
+  expect(wrapper.element.getAttribute('class')).toBe('fa-layers-text')
   expect(wrapper.element.innerHTML).toBe('')
 })
 
 test('simple text', () => {
-  const wrapper = compileAndMount({
-    template: '<font-awesome-layers-text value="Test" />',
-    components: {
-      FontAwesomeLayersText
-    }
-  })
+  const wrapper = mountLayersText('<font-awesome-layers-text value="Test" />')
 
   expect(wrapper.element.getAttribute('class')).toBe('fa-layers-text')
   expect(wrapper.element.innerHTML).toBe('Test')
 })
 
 test('accept number for value', () => {
-  const wrapper = compileAndMount({
-    template: '<font-awesome-layers-text :value="42" />',
-    components: {
-      FontAwesomeLayersText
-    }
-  })
+  const wrapper = mountLayersText('<font-awesome-layers-text :value="42" />')
 
   expect(wrapper.element.getAttribute('class')).toBe('fa-layers-text')
   expect(wrapper.element.innerHTML).toBe('42')
@@ -45,39 +34,24 @@ test('accept number for value', () => {
 
 describe('transform', () => {
   test('string', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers-text value="1" transform="shrink-6" />',
-      components: {
-        FontAwesomeLayersText
-      }
-    })
+    const wrapper = mountLayersText('<font-awesome-layers-text value="1" transform="shrink-6" />')
 
     expect(wrapper.element.tagName).toBe('SPAN')
-    expect(wrapper.element.classList.contains('fa-layers-text')).toBeTruthy()
+    expect(wrapper.element.getAttribute('class')).toBe('fa-layers-text')
     expect(wrapper.element.innerHTML).toBe('1')
   })
 })
 
 describe('counter', () => {
   test('simple', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers-text :value="42" :counter="true" />',
-      components: {
-        FontAwesomeLayersText
-      }
-    })
+    const wrapper = mountLayersText('<font-awesome-layers-text :value="42" :counter="true" />')
 
     expect(wrapper.element.getAttribute('class')).toBe('fa-layers-counter')
     expect(wrapper.element.innerHTML).toBe('42')
   })
 
   test('position', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers-text value="42" counter position="bottom-right" />',
-      components: {
-        FontAwesomeLayersText
-      }
-    })
+    const wrapper = mountLayersText('<font-awesome-layers-text value="42" counter position="bottom-right" />')
 
     expect(wrapper.element.getAttribute('class')).toBe('fa-layers-counter fa-layers-bottom-right')
   })
@@ -85,36 +59,21 @@ describe('counter', () => {
 
 describe('class attr', () => {
   test('user-provided class is applied alongside fa-layers-text', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers-text value="New!" class="gray8" />',
-      components: {
-        FontAwesomeLayersText
-      }
-    })
+    const wrapper = mountLayersText('<font-awesome-layers-text value="New!" class="gray8" />')
 
     expect(wrapper.element.classList.contains('fa-layers-text')).toBeTruthy()
     expect(wrapper.element.classList.contains('gray8')).toBeTruthy()
   })
 
   test('fa-inverse is applied alongside fa-layers-text', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers-text value="NEW" class="fa-inverse" />',
-      components: {
-        FontAwesomeLayersText
-      }
-    })
+    const wrapper = mountLayersText('<font-awesome-layers-text value="NEW" class="fa-inverse" />')
 
     expect(wrapper.element.classList.contains('fa-layers-text')).toBeTruthy()
     expect(wrapper.element.classList.contains('fa-inverse')).toBeTruthy()
   })
 
   test('user-provided class is applied alongside fa-layers-counter', () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers-text :value="42" :counter="true" class="fa-inverse" />',
-      components: {
-        FontAwesomeLayersText
-      }
-    })
+    const wrapper = mountLayersText('<font-awesome-layers-text :value="42" :counter="true" class="fa-inverse" />')
 
     expect(wrapper.element.classList.contains('fa-layers-counter')).toBeTruthy()
     expect(wrapper.element.classList.contains('fa-inverse')).toBeTruthy()

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -49,8 +49,9 @@ describe('transform', () => {
       }
     })
 
-    // It appears the jsdom doesn't set the transform for this, not sure why
-    expect(wrapper.element)
+    expect(wrapper.element.tagName).toBe('SPAN')
+    expect(wrapper.element.classList.contains('fa-layers-text')).toBeTruthy()
+    expect(wrapper.element.innerHTML).toBe('1')
   })
 })
 

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -92,8 +92,8 @@ describe('class attr', () => {
       }
     })
 
-    expect(wrapper.element.classList.contains('fa-layers-text')).toBe(true)
-    expect(wrapper.element.classList.contains('gray8')).toBe(true)
+    expect(wrapper.element.classList.contains('fa-layers-text')).toBeTruthy()
+    expect(wrapper.element.classList.contains('gray8')).toBeTruthy()
   })
 
   test('fa-inverse is applied alongside fa-layers-text', () => {
@@ -104,8 +104,8 @@ describe('class attr', () => {
       }
     })
 
-    expect(wrapper.element.classList.contains('fa-layers-text')).toBe(true)
-    expect(wrapper.element.classList.contains('fa-inverse')).toBe(true)
+    expect(wrapper.element.classList.contains('fa-layers-text')).toBeTruthy()
+    expect(wrapper.element.classList.contains('fa-inverse')).toBeTruthy()
   })
 
   test('user-provided class is applied alongside fa-layers-counter', () => {
@@ -116,8 +116,8 @@ describe('class attr', () => {
       }
     })
 
-    expect(wrapper.element.classList.contains('fa-layers-counter')).toBe(true)
-    expect(wrapper.element.classList.contains('fa-inverse')).toBe(true)
+    expect(wrapper.element.classList.contains('fa-layers-counter')).toBeTruthy()
+    expect(wrapper.element.classList.contains('fa-inverse')).toBeTruthy()
   })
 })
 

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -15,6 +15,8 @@ test('empty', () => {
   })
 
   expect(wrapper.element.tagName).toBe('SPAN')
+  expect(wrapper.element.classList.contains('fa-layers-text')).toBeTruthy()
+  expect(wrapper.element.innerHTML).toBe('')
 })
 
 test('simple text', () => {

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -65,7 +65,6 @@ describe('counter', () => {
     })
 
     expect(wrapper.element.getAttribute('class')).toBe('fa-layers-counter')
-    expect(wrapper.element.getAttribute('class')).not.toBe('fa-layers-text')
     expect(wrapper.element.innerHTML).toBe('42')
   })
 

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -4,6 +4,7 @@
 
 import { compileAndMount } from '../__fixtures__/helpers'
 import FontAwesomeLayersText from '../FontAwesomeLayersText'
+import { mount } from '@vue/test-utils'
 
 test('empty', () => {
   const wrapper = compileAndMount({
@@ -120,12 +121,7 @@ describe('class attr', () => {
 
 describe('reactivity', () => {
   test('changing props should update the element', async () => {
-    const wrapper = compileAndMount({
-      template: '<font-awesome-layers-text :value="42" :counter="true" />',
-      components: {
-        FontAwesomeLayersText
-      }
-    })
+    const wrapper = mount(FontAwesomeLayersText, { props: { value: 42, counter: true } })
 
     expect(wrapper.element.innerHTML).toBe('42')
 

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { compileAndMount } from '../__fixtures__/helpers'
 import FontAwesomeLayersText from '../FontAwesomeLayersText'
 import { mount } from '@vue/test-utils'

--- a/src/components/__tests__/FontAwesomeLayersText.test.js
+++ b/src/components/__tests__/FontAwesomeLayersText.test.js
@@ -33,7 +33,7 @@ test('accept number for value', () => {
 })
 
 describe('transform', () => {
-  test('string', () => {
+  test('accepts string transform prop', () => {
     const wrapper = mountLayersText('<font-awesome-layers-text value="1" transform="shrink-6" />')
 
     expect(wrapper.element.tagName).toBe('SPAN')
@@ -57,7 +57,7 @@ describe('counter', () => {
   })
 })
 
-describe('class attr', () => {
+describe('class attribute coexistence', () => {
   test('user-provided class is applied alongside fa-layers-text', () => {
     const wrapper = mountLayersText('<font-awesome-layers-text value="New!" class="gray8" />')
 


### PR DESCRIPTION
This PR updates the component test suite:
- Refactors several Vue component tests to use shared mount helpers and clearer assertions.
- Adds/extends version-gated tests (feature-flag driven) for core-version-dependent behavior.
- Documents how to run the test suite against Font Awesome SVG Core v1/v6/v7.