### PR TITLE
improve TypeScript types for icon and mask props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
-import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
+import { IconDefinition, IconLookup, IconName, IconPrefix } from '@fortawesome/fontawesome-svg-core'
 import { DefineComponent } from 'vue'
+
+type IconProp = IconDefinition | IconLookup | [IconPrefix, IconName] | IconName | (string & {}) | object
 
 interface GradientStop {
   offset: string | number
@@ -32,8 +34,8 @@ interface FontAwesomeIconProps {
   border?: boolean
   fixedWidth?: boolean
   flip?: 'horizontal' | 'vertical' | 'both' | boolean
-  icon: object | Array<string> | string | IconDefinition
-  mask?: object | Array<string> | string
+  icon: IconProp
+  mask?: IconProp
   maskId?: string
   listItem?: boolean
   pull?: 'right' | 'left'
@@ -75,4 +77,4 @@ declare const FontAwesomeIcon: DefineComponent<FontAwesomeIconProps>
 declare const FontAwesomeLayers: DefineComponent<FontAwesomeLayersProps>
 declare const FontAwesomeLayersText: DefineComponent<FontAwesomeLayersTextProps>
 
-export { FontAwesomeIcon, FontAwesomeIconProps, FontAwesomeLayers, FontAwesomeLayersProps, FontAwesomeLayersText, FontAwesomeLayersTextProps, GradientStop, LinearGradientFill, RadialGradientFill }
+export { FontAwesomeIcon, FontAwesomeIconProps, FontAwesomeLayers, FontAwesomeLayersProps, FontAwesomeLayersText, FontAwesomeLayersTextProps, GradientStop, LinearGradientFill, RadialGradientFill, IconProp }


### PR DESCRIPTION
This PR replaces the [Properly infer icons type](https://github.com/FortAwesome/vue-fontawesome/pull/484).

## Summary

Improves the TypeScript developer experience for the `icon` and `mask` props by introducing a proper `IconProp` type that leverages the specific types already exported by `@fortawesome/fontawesome-svg-core`.

## What changed

- Introduced and exported an `IconProp` type that replaces the previous loosely-typed `object | Array<string> | string | IconDefinition`
- `icon` and `mask` props now use `IconProp`, giving IDE autocomplete for icon names and prefixes
- `mask` now explicitly includes `IconDefinition` in its type (the runtime already supported this)

Both `icon` and `mask` accept the same `IconProp` type and are processed through the same `normalizeIconArgs` function at runtime, so all forms are supported equally for both props:

- `IconDefinition` — full icon object imported from a package (e.g. `import { faHouse } from '@fortawesome/free-solid-svg-icons'`)
- `IconLookup` — `{ prefix: 'fas', iconName: 'house' }`
- `[IconPrefix, IconName]` — array shorthand, e.g. `['fas', 'house']`
- `IconName` — bare name string, e.g. `'house'` (defaults to `fas` prefix)
- `string` — FA string syntax, e.g. `'fa-solid fa-house'`
- `object` — catch-all for custom/raw icon objects

## Backward compatibility

No breaking changes. All previously accepted values are still accepted:

- `icon="coffee"` — plain strings still work via `(string & {})`
- `icon="['fas', 'coffee']"` — arrays still work via `object`
- `icon={faCoffee}` — `IconDefinition` objects still work
- Custom icon packs and non-standard prefixes still work via `object`

## For Users

You can now import `IconProp` directly from `@fortawesome/vue-fontawesome` to type your own component props or variables:

​```typescript
import { IconProp } from '@fortawesome/vue-fontawesome'

interface MyProps {
  icon: IconProp
}
​```

**Note:** `@fortawesome/fontawesome-svg-core` also exports an `IconProp` type, but it is a narrower subset — it does not include `IconDefinition`, arbitrary strings, or custom icon objects. If you are using `vue-fontawesome`, prefer importing `IconProp` from `@fortawesome/vue-fontawesome`. 

`IconProp` from `@fortawesome/vue-fontawesome` is a superset of `fontawesome-svg-core`'s.

