### PR TITLE
accept 0 as rotation value (issue #336)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ interface FontAwesomeIconProps {
   listItem?: boolean
   pull?: 'right' | 'left'
   pulse?: boolean
-  rotation?: 90 | 180 | 270 | '90' | '180' | '270'
+  rotation?: 0 | 90 | 180 | 270 | '0' | '90' | '180' | '270'
   rotateBy?: boolean
   swapOpacity?: boolean
   size?: '2xs' | 'xs' | 'sm' | 'lg' | 'xl' | '2xl' | '1x' | '2x' | '3x' | '4x' | '5x' | '6x' | '7x' | '8x' | '9x' | '10x'

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -77,7 +77,7 @@ export default defineComponent({
     rotation: {
       type: [String, Number],
       default: null,
-      validator: (value) => [90, 180, 270].indexOf(Number.parseInt(value, 10)) > -1
+      validator: (value) => [0, 90, 180, 270].indexOf(Number.parseInt(value, 10)) > -1
     },
     // the rotateBy property is only supported in version 7.0.0 and later
     rotateBy: {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -318,6 +318,12 @@ describe('using rotation', () => {
 
     consoleSpy.mockRestore()
   })
+
+  test('null does not add any rotation class', () => {
+    const wrapper = mountFromProps({ icon: faCoffee, rotation: null })
+
+    expect(wrapper.element.getAttribute('class')).not.toMatch(/fa-rotate-/)
+  })
 })
 
 describe('using rotateBy', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -299,16 +299,24 @@ describe('using rotation', () => {
     expect(wrapper.element.classList.contains('fa-rotate-90')).toBeTruthy()
   })
 
-  test('0 does not add a rotation class', () => {
+  test('0 does not add a rotation class and does not warn', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const wrapper = mountFromProps({ icon: faCoffee, rotation: 0 })
 
     expect(wrapper.element.classList.contains('fa-rotate-0')).toBeFalsy()
+    expect(consoleSpy).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
   })
 
-  test('0 as a string does not add a rotation class', () => {
+  test('0 as a string does not add a rotation class and does not warn', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const wrapper = mountFromProps({ icon: faCoffee, rotation: '0' })
 
     expect(wrapper.element.classList.contains('fa-rotate-0')).toBeFalsy()
+    expect(consoleSpy).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
   })
 })
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -289,24 +289,28 @@ describe('using rotation', () => {
     const wrapper = mountFromProps({ icon: faCoffee, rotation: 90 })
 
     expect(wrapper.element.classList.contains('fa-rotate-90')).toBeTruthy()
+    expect(consoleSpy).not.toHaveBeenCalled()
   })
 
   test('180', () => {
     const wrapper = mountFromProps({ icon: faCoffee, rotation: 180 })
 
     expect(wrapper.element.classList.contains('fa-rotate-180')).toBeTruthy()
+    expect(consoleSpy).not.toHaveBeenCalled()
   })
 
   test('270', () => {
     const wrapper = mountFromProps({ icon: faCoffee, rotation: 270 })
 
     expect(wrapper.element.classList.contains('fa-rotate-270')).toBeTruthy()
+    expect(consoleSpy).not.toHaveBeenCalled()
   })
 
   test('as a string', () => {
     const wrapper = mountFromProps({ icon: faCoffee, rotation: '90' })
 
     expect(wrapper.element.classList.contains('fa-rotate-90')).toBeTruthy()
+    expect(consoleSpy).not.toHaveBeenCalled()
   })
 
   test('0 does not add a rotation class and does not warn', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -298,6 +298,18 @@ describe('using rotation', () => {
 
     expect(wrapper.element.classList.contains('fa-rotate-90')).toBeTruthy()
   })
+
+  test('0 does not add a rotation class', () => {
+    const wrapper = mountFromProps({ icon: faCoffee, rotation: 0 })
+
+    expect(wrapper.element.classList.contains('fa-rotate-0')).toBeFalsy()
+  })
+
+  test('0 as a string does not add a rotation class', () => {
+    const wrapper = mountFromProps({ icon: faCoffee, rotation: '0' })
+
+    expect(wrapper.element.classList.contains('fa-rotate-0')).toBeFalsy()
+  })
 })
 
 describe('using rotateBy', () => {

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -275,6 +275,16 @@ describe('using pull', () => {
 })
 
 describe('using rotation', () => {
+  let consoleSpy
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleSpy.mockRestore()
+  })
+
   test('90', () => {
     const wrapper = mountFromProps({ icon: faCoffee, rotation: 90 })
 
@@ -300,23 +310,17 @@ describe('using rotation', () => {
   })
 
   test('0 does not add a rotation class and does not warn', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const wrapper = mountFromProps({ icon: faCoffee, rotation: 0 })
 
     expect(wrapper.element.classList.contains('fa-rotate-0')).toBeFalsy()
     expect(consoleSpy).not.toHaveBeenCalled()
-
-    consoleSpy.mockRestore()
   })
 
   test('0 as a string does not add a rotation class and does not warn', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const wrapper = mountFromProps({ icon: faCoffee, rotation: '0' })
 
     expect(wrapper.element.classList.contains('fa-rotate-0')).toBeFalsy()
     expect(consoleSpy).not.toHaveBeenCalled()
-
-    consoleSpy.mockRestore()
   })
 
   test('null does not add any rotation class', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,7 +15,7 @@ export function classList(props) {
     'fa-flip-horizontal': props.flip === 'horizontal' || props.flip === 'both',
     'fa-flip-vertical': props.flip === 'vertical' || props.flip === 'both',
     [`fa-${props.size}`]: props.size !== null,
-    [`fa-rotate-${props.rotation}`]: props.rotation !== null,
+    [`fa-rotate-${props.rotation}`]: props.rotation !== null && props.rotation !== 0 && props.rotation !== '0',
     'fa-rotate-by': props.rotateBy,
     [`fa-pull-${props.pull}`]: props.pull !== null,
     'fa-swap-opacity': props.swapOpacity,


### PR DESCRIPTION
## Summary

Fixes issue [#336](https://github.com/FortAwesome/vue-fontawesome/issues/336).

The `rotation` prop validator only accepted `90`, `180`, and `270`. 

Passing `0` fired:

```
[Vue warn] Invalid prop: custom validator check failed for prop "rotation"
```

…even though `0` is a semantically valid "no rotation" value. This is particularly painful when binding rotation dynamically from a variable that can be `0` (e.g. a select bound to `0 | 90 | 180 | 270`). The previously suggested workaround was to normalize `0` to `null` at the call site — a non-obvious implementation detail that surprises consumers.

## Changes

- **`src/components/FontAwesomeIcon.js`** — added `0` to the validator whitelist.
- **`src/utils.js`** — `0` and `'0'` no longer add a `fa-rotate-0` class
  (no such class exists in FontAwesome's CSS, so applying it would be a misleading no-op).
- **`index.d.ts`** — added `0 | '0'` to the `rotation` union type.
- **`src/components/__tests__/FontAwesomeIcon.test.js`** — two new tests
  covering `rotation: 0` and `rotation: '0'`.

## Backward Compatibility

No breaking changes:

- `null` (default) — unchanged, no class applied.
- `0` / `'0'` — newly accepted, no class applied (was a warning before).
- `90` / `180` / `270` — unchanged, `fa-rotate-{value}` applied.

`0` was previously rejected outright, so no existing code could have relied on
specific behavior when passing it. Users currently normalizing `0` to `null` at
the call site can stop doing so but don't have to.

## Test plan

- [x] `npm test` — 99 passed (97 existing + 2 new)
- [x] `npm run build` — clean build, new logic confirmed in `index.es.js`
- [x] Manually verified in my local test repo