### PR TITLE
new animations for 7.3.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,15 @@ interface FontAwesomeIconProps {
   spinReverse?: boolean
   widthAuto?: boolean
   gradientFill?: LinearGradientFill | RadialGradientFill
+  flip360?: boolean
+  buzz?: boolean
+  float?: boolean
+  jello?: boolean
+  spinSnap?: boolean
+  spinSnap4?: boolean
+  spinSnap8?: boolean
+  swing?: boolean
+  wag?: boolean
 }
 
 interface FontAwesomeLayersProps {
@@ -77,4 +86,15 @@ declare const FontAwesomeIcon: DefineComponent<FontAwesomeIconProps>
 declare const FontAwesomeLayers: DefineComponent<FontAwesomeLayersProps>
 declare const FontAwesomeLayersText: DefineComponent<FontAwesomeLayersTextProps>
 
-export { FontAwesomeIcon, FontAwesomeIconProps, FontAwesomeLayers, FontAwesomeLayersProps, FontAwesomeLayersText, FontAwesomeLayersTextProps, GradientStop, LinearGradientFill, RadialGradientFill, IconProp }
+export {
+  FontAwesomeIcon,
+  FontAwesomeIconProps,
+  FontAwesomeLayers,
+  FontAwesomeLayersProps,
+  FontAwesomeLayersText,
+  FontAwesomeLayersTextProps,
+  GradientStop,
+  LinearGradientFill,
+  RadialGradientFill,
+  IconProp
+}

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -168,6 +168,43 @@ export default defineComponent({
         }
         return true
       }
+    },
+    // the following animation properties are only supported in version 7.3.0 and later
+    flip360: {
+      type: Boolean,
+      default: false
+    },
+    buzz: {
+      type: Boolean,
+      default: false
+    },
+    float: {
+      type: Boolean,
+      default: false
+    },
+    jello: {
+      type: Boolean,
+      default: false
+    },
+    spinSnap: {
+      type: Boolean,
+      default: false
+    },
+    spinSnap4: {
+      type: Boolean,
+      default: false
+    },
+    spinSnap8: {
+      type: Boolean,
+      default: false
+    },
+    swing: {
+      type: Boolean,
+      default: false
+    },
+    wag: {
+      type: Boolean,
+      default: false
     }
   },
 

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -198,7 +198,7 @@ describe('display props', () => {
     ['fixedWidth', 'fa-fw'],
     ['widthAuto', 'fa-width-auto'],
     ['inverse', 'fa-inverse'],
-    ['swapOpacity', 'fa-swap-opacity'],
+    ['swapOpacity', 'fa-swap-opacity']
   ])('using %s', (prop, cls) => {
     const wrapper = mountFromProps({ icon: faCoffee, [prop]: true })
     expect(wrapper.element.classList.contains(cls)).toBeTruthy()
@@ -217,6 +217,15 @@ describe('animation props', () => {
     ['flash', 'fa-flash'],
     ['spinPulse', 'fa-spin-pulse'],
     ['spinReverse', 'fa-spin-reverse'],
+    ['flip360', 'fa-flip-360'],
+    ['buzz', 'fa-buzz'],
+    ['float', 'fa-float'],
+    ['jello', 'fa-jello'],
+    ['spinSnap', 'fa-spin-snap'],
+    ['spinSnap4', 'fa-spin-snap-4'],
+    ['spinSnap8', 'fa-spin-snap-8'],
+    ['swing', 'fa-swing'],
+    ['wag', 'fa-wag']
   ])('using %s', (prop, cls) => {
     const wrapper = mountFromProps({ icon: faCoffee, [prop]: true })
     expect(wrapper.element.classList.contains(cls)).toBeTruthy()

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,17 @@ export function classList(props) {
     'fa-spin-pulse': props.spinPulse,
     'fa-spin-reverse': props.spinReverse,
     // the widthAuto property is only supported in version 7.0.0 and later
-    'fa-width-auto': props.widthAuto
+    'fa-width-auto': props.widthAuto,
+    // the following animations are only supported in version 7.3.0 and later
+    'fa-flip-360': props.flip360,
+    'fa-buzz': props.buzz,
+    'fa-float': props.float,
+    'fa-jello': props.jello,
+    'fa-spin-snap': props.spinSnap,
+    'fa-spin-snap-4': props.spinSnap4,
+    'fa-spin-snap-8': props.spinSnap8,
+    'fa-swing': props.swing,
+    'fa-wag': props.wag
   }
 
   return Object.keys(classes)


### PR DESCRIPTION
This PR adds support for the 9 new animation introduced in `@fortawesome/fontawesome-svg-core@7.3.0`.

Prop | CSS class
-- | --
flip360 | fa-flip-360
buzz | fa-buzz
float | fa-float
jello | fa-jello
spinSnap | fa-spin-snap
spinSnap4 | fa-spin-snap-4
spinSnap8 | fa-spin-snap-8
swing | fa-swing
wag | fa-wag

@robmadole --- could you review the code for correctness?