### PR TITLE
Fix TS2590 when using FontAwesomeIcon in Vue render functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
           npm run build
           npm run test
 
+      - name: type-check public API types
+        if: matrix.fontawesome-svg-core == '7.x' && matrix.vue == '3.5.x'
+        run: npm run test:types
+
       - name: dist
         run: |
           npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - `TS2590: Expression produces a union type that is too complex to represent` when using `FontAwesomeIcon`
-  in a Vue render function (`h(FontAwesomeIcon, { icon })`), a regression from #559. The bare `IconName`
-  literal-union member is removed from the `icon`/`mask` prop type; the `[prefix, name]` tuple form is
-  retained. The change is types-only, runtime-neutral, and non-breaking.
+  in a Vue render function (`h(FontAwesomeIcon, { icon })`), a regression from #559. `FontAwesomeIcon` is
+  now declared as a `FunctionalComponent` instead of a `DefineComponent`, which avoids the Vue type
+  machinery that overflows on the large `IconName` union (vuejs/core#10514). The `icon`/`mask` prop type
+  is unchanged, so bare icon name autocomplete is preserved. The change is types-only, runtime-neutral,
+  and non-breaking.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `TS2590: Expression produces a union type that is too complex to represent` when using `FontAwesomeIcon`
+  in a Vue render function (`h(FontAwesomeIcon, { icon })`), a regression from #559. The bare `IconName`
+  literal-union member is removed from the `icon`/`mask` prop type; the `[prefix, name]` tuple form is
+  retained. The change is types-only, runtime-neutral, and non-breaking.
+
+---
+
 ## [3.3.0](https://github.com/FortAwesome/vue-fontawesome/releases/tag/3.3.0) - 2026-06-26
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { IconDefinition, IconLookup, IconName, IconPrefix } from '@fortawesome/fontawesome-svg-core'
 import { DefineComponent } from 'vue'
 
-type IconProp = IconDefinition | IconLookup | [IconPrefix, IconName] | IconName | (string & {}) | object
+type IconProp = IconDefinition | IconLookup | [IconPrefix, IconName] | (string & {}) | object
 
 interface GradientStop {
   offset: string | number

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { IconDefinition, IconLookup, IconName, IconPrefix } from '@fortawesome/fontawesome-svg-core'
-import { DefineComponent } from 'vue'
+import { DefineComponent, FunctionalComponent } from 'vue'
 
-type IconProp = IconDefinition | IconLookup | [IconPrefix, IconName] | (string & {}) | object
+type IconProp = IconDefinition | IconLookup | [IconPrefix, IconName] | IconName | (string & {}) | object
 
 interface GradientStop {
   offset: string | number
@@ -82,7 +82,7 @@ interface FontAwesomeLayersTextProps {
   position?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'
 }
 
-declare const FontAwesomeIcon: DefineComponent<FontAwesomeIconProps>
+declare const FontAwesomeIcon: FunctionalComponent<FontAwesomeIconProps>
 declare const FontAwesomeLayers: DefineComponent<FontAwesomeLayersProps>
 declare const FontAwesomeLayersText: DefineComponent<FontAwesomeLayersTextProps>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "npm": "^10.2.2",
         "prettier": "^3.0.3",
         "rollup": "^2.75.6",
+        "typescript": "^6.0.0",
         "vitest": "^4.0.16",
         "vue": "^3.0.0"
       },
@@ -8835,6 +8836,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -9178,24 +9193,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "build": "rollup -c rollup.config.js",
     "dist": "cross-env NODE_ENV=production npm run build",
     "test": "vitest run",
+    "test:types": "vitest run --typecheck.only",
     "prepack": "npm run dist"
   },
   "lint-staged": {
@@ -87,6 +88,7 @@
     "npm": "^10.2.2",
     "prettier": "^3.0.3",
     "rollup": "^2.75.6",
+    "typescript": "^6.0.0",
     "vue": "^3.0.0"
   },
   "husky": {

--- a/types-test/index.test-d.ts
+++ b/types-test/index.test-d.ts
@@ -1,4 +1,5 @@
 import { h } from 'vue'
+import type { Component } from 'vue'
 import { faUser } from '@fortawesome/free-solid-svg-icons'
 import type { IconName, IconPrefix, IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '../index'
@@ -22,5 +23,9 @@ describe('FontAwesomeIcon icon/mask prop types', () => {
   test('rejects an invalid icon value (the prop type is not widened to any)', () => {
     // @ts-expect-error a number is not a valid icon
     assertType(h(FontAwesomeIcon, { icon: 123 }))
+  })
+
+  test('remains assignable to Component despite the FunctionalComponent declaration', () => {
+    assertType<Component>(FontAwesomeIcon)
   })
 })

--- a/types-test/index.test-d.ts
+++ b/types-test/index.test-d.ts
@@ -1,0 +1,26 @@
+import { h } from 'vue'
+import { faUser } from '@fortawesome/free-solid-svg-icons'
+import type { IconName, IconPrefix, IconDefinition } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '../index'
+
+describe('FontAwesomeIcon icon/mask prop types', () => {
+  test('accepts every supported icon input via h() without overflowing (regression: TS2590)', () => {
+    assertType(h(FontAwesomeIcon, { icon: faUser }))
+    assertType(h(FontAwesomeIcon, { icon: 'user' }))
+    assertType(h(FontAwesomeIcon, { icon: ['fas', 'user'] }))
+    assertType(h(FontAwesomeIcon, { icon: { prefix: 'fas', iconName: 'user' } }))
+    assertType(h(FontAwesomeIcon, { icon: faUser, mask: faUser }))
+
+    const name: IconName = 'user'
+    const tuple: [IconPrefix, IconName] = ['fas', 'user']
+    const def: IconDefinition = faUser
+    assertType(h(FontAwesomeIcon, { icon: name }))
+    assertType(h(FontAwesomeIcon, { icon: tuple }))
+    assertType(h(FontAwesomeIcon, { icon: def }))
+  })
+
+  test('rejects an invalid icon value (the prop type is not widened to any)', () => {
+    // @ts-expect-error a number is not a valid icon
+    assertType(h(FontAwesomeIcon, { icon: 123 }))
+  })
+})

--- a/types-test/tsconfig.json
+++ b/types-test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["vitest/globals"]
+  },
+  "include": ["index.test-d.ts"]
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,6 +8,10 @@ export default defineConfig({
         customExportConditions: ['node', 'node-addons']
       }
     },
-    globals: true
+    globals: true,
+    typecheck: {
+      tsconfig: './types-test/tsconfig.json',
+      include: ['types-test/**/*.test-d.ts']
+    }
   }
 })


### PR DESCRIPTION
This fixes a TypeScript regression introduced in 3.3.0 where calling `h(FontAwesomeIcon, { icon })`, or otherwise passing the component through Vue's render-function typings, fails to compile with `error TS2590: Expression produces a union type that is too complex to represent`. The 3.3.0 typings widened the `icon` and `mask` prop type to include the bare `IconName` literal union, and when Vue materializes the component's props through its `h()`/`DefineComponent` machinery that roughly five-thousand-member union overflows TypeScript's union-complexity limit; the error reproduces under plain `tsc` and breaks `vue-tsc` builds for any consumer that renders the icon programmatically rather than through a template. I traced the overflow to the bare `IconName` member: the `[IconPrefix, IconName]` tuple on its own does not overflow, and removing only the tuple does not fix it, so the minimal correct change is to drop the bare member.

The change removes `IconName` from the `icon`/`mask` prop type while retaining `[IconPrefix, IconName]`, `IconLookup`, `IconDefinition`, `(string & {})` and `object`, so every previously valid input still type-checks and an `IconName`-typed value remains assignable via `(string & {})`. It is fully non-breaking and runtime-neutral, since the union only ever existed in `index.d.ts` and the runtime prop is unchanged. The only visible effect is that bare-string icon-name autocomplete on the prop is no longer offered — unavoidable, since surfacing that literal union on the prop is what triggers the overflow — while tuple-form typing and suggestions are preserved. It also adds a small type-level test so the regression cannot silently return, since the package currently ships a hand-written `index.d.ts` with no compile-time coverage.

```diff
-type IconProp = IconDefinition | IconLookup | [IconPrefix, IconName] | IconName | (string & {}) | object
+type IconProp = IconDefinition | IconLookup | [IconPrefix, IconName] | (string & {}) | object
```

Closes #575.