### PR TITLE
Fix ERESOLVE failures in the CI Vue version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,7 @@ jobs:
         run: |
           npm install
           npm install --no-save @fortawesome/fontawesome-svg-core@${{ matrix.fontawesome-svg-core }} @fortawesome/free-solid-svg-icons@${{ matrix.free-solid-svg-icons }}
-          npm install --no-save vue@${{ matrix.vue }}
-          VER=$(npm list vue | grep vue@ | cut -d@ -f3)
-          if [ "$(printf '%s\n' "3.2.12" "$VER" | sort -V | head -n1)" = "$VER" ]; then
-            npm install --no-save @vue/server-renderer@${{ matrix.vue }}
-          fi
+          npm install --no-save --legacy-peer-deps vue@${{ matrix.vue }} @vue/server-renderer@${{ matrix.vue }}
           npm run build
           npm run test
 


### PR DESCRIPTION
CI on `3.x` has been failing for every Vue 3.0–3.4 matrix row due to PR #576, but the type changes are not the cause. The `@vue/server-renderer` pin in the workflow is guarded by a version check that has never worked: `npm list vue | grep vue@ | cut -d@ -f3` reads the wrong field and always yields an empty string, so the pin runs for every Vue version. Because the preceding downgrade uses `--no-save`, npm resolves that extra install against `package-lock.json`, which still pins `vue@3.5.39`, and whether the resulting peer conflict is tolerated depends on incidental lockfile content. Adding `typescript` to the lockfile in #576 flipped it from a warning into a hard `ERESOLVE` failure, and regenerating the lockfile does not help.

This replaces the guarded two-step dance with a single `npm install --no-save --legacy-peer-deps vue@X @vue/server-renderer@X`, which deterministically installs a matched pair regardless of what the lockfile pins. I replayed the workflow's install sequence with npm 10.9.8 for all six Vue versions in the matrix, and ran the build and full test suite against the resulting Vue 3.0, 3.3, and 3.5 trees, all passing.