### PR TITLE
Add new canvas sizing options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,8 @@ interface FontAwesomeIconProps {
   spinPulse?: boolean
   spinReverse?: boolean
   widthAuto?: boolean
+  canvasSquare?: boolean
+  canvasRoomy?: boolean
   gradientFill?: LinearGradientFill | RadialGradientFill
   flip360?: boolean
   buzz?: boolean

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -154,6 +154,15 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    // the canvasSquare and canvasRoomy properties are only supported in version 7.3.0 and later
+    canvasSquare: {
+      type: Boolean,
+      default: false
+    },
+    canvasRoomy: {
+      type: Boolean,
+      default: false
+    },
     gradientFill: {
       type: Object,
       default: null,

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -197,6 +197,8 @@ describe('display props', () => {
     ['listItem', 'fa-li'],
     ['fixedWidth', 'fa-fw'],
     ['widthAuto', 'fa-width-auto'],
+    ['canvasSquare', 'fa-canvas-square'],
+    ['canvasRoomy', 'fa-canvas-roomy'],
     ['inverse', 'fa-inverse'],
     ['swapOpacity', 'fa-swap-opacity']
   ])('using %s', (prop, cls) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,9 @@ export function classList(props) {
     'fa-spin-reverse': props.spinReverse,
     // the widthAuto property is only supported in version 7.0.0 and later
     'fa-width-auto': props.widthAuto,
+    // the canvasSquare and canvasRoomy properties are only supported in version 7.3.0 and later
+    'fa-canvas-square': props.canvasSquare,
+    'fa-canvas-roomy': props.canvasRoomy,
     // the following animations are only supported in version 7.3.0 and later
     'fa-flip-360': props.flip360,
     'fa-buzz': props.buzz,


### PR DESCRIPTION
Version 7.3 included [new canvas sizing options - Square and Roomy](https://docs.fontawesome.com/web/style/icon-canvas#adjusting-canvas-sizing). This PR brings those options to the Vue component. 