### PR TITLE
Fix class/style type-checking on FontAwesomeIcon in TSX (#582)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,14 @@ jobs:
           npm run build
           npm run test
 
+      # Type-check the public API against both the newest and oldest supported Vue.
+      # The matrix step above has already swapped in vue@${{ matrix.vue }}, so this
+      # runs test:types against that version. Covering the floor (3.0.x) as well as
+      # the ceiling (3.5.x) catches type-only regressions that depend on a helper
+      # that older Vue does not export (peer range is vue >= 3.0.0) — a gap a
+      # 3.5-only check silently misses.
       - name: type-check public API types
-        if: matrix.fontawesome-svg-core == '7.x' && matrix.vue == '3.5.x'
+        if: matrix.fontawesome-svg-core == '7.x' && (matrix.vue == '3.5.x' || matrix.vue == '3.0.x')
         run: npm run test:types
 
       - name: dist

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { IconDefinition, IconLookup, IconName, IconPrefix } from '@fortawesome/fontawesome-svg-core'
-import { DefineComponent, FunctionalComponent } from 'vue'
+import { DefineComponent, FunctionalComponent, AllowedComponentProps, VNodeProps } from 'vue'
 
 type IconProp = IconDefinition | IconLookup | [IconPrefix, IconName] | IconName | (string & {}) | object
 
@@ -84,7 +84,7 @@ interface FontAwesomeLayersTextProps {
   position?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'
 }
 
-declare const FontAwesomeIcon: FunctionalComponent<FontAwesomeIconProps>
+declare const FontAwesomeIcon: FunctionalComponent<FontAwesomeIconProps & AllowedComponentProps & VNodeProps>
 declare const FontAwesomeLayers: DefineComponent<FontAwesomeLayersProps>
 declare const FontAwesomeLayersText: DefineComponent<FontAwesomeLayersTextProps>
 

--- a/types-test/index.test-d.ts
+++ b/types-test/index.test-d.ts
@@ -30,16 +30,17 @@ describe('FontAwesomeIcon icon/mask prop types', () => {
   })
 })
 
-describe('FontAwesomeIcon global attributes (regression: #582)', () => {
-  // Since 3.3.1, FontAwesomeIcon is declared as a FunctionalComponent. In JSX/TSX a
-  // functional component's accepted attributes resolve from the first parameter of
-  // its call signature — so that surface must carry Vue's global component props
-  // (class, style via AllowedComponentProps; key, ref via VNodeProps), or
-  // `<FontAwesomeIcon class="..."/>` fails to type-check (issue #582). The existing
-  // h()-based tests above could not catch this: h()'s RawProps includes a
-  // `Record<string, any>` index signature that accepts any attribute, masking the gap.
-  // These assertions target the call-signature parameter directly — the exact type
-  // TSX consults — without needing a JSX parser.
+describe('FontAwesomeIcon global attributes in JSX/TSX', () => {
+  // FontAwesomeIcon is declared as a FunctionalComponent. In JSX/TSX a functional
+  // component's accepted attributes resolve from the first parameter of its call
+  // signature, so that surface must carry Vue's global component props — class and
+  // style from AllowedComponentProps, key and ref from VNodeProps — otherwise
+  // `<FontAwesomeIcon class="..." />` fails to type-check.
+  //
+  // The h()-based tests above cannot cover this: h()'s RawProps includes a
+  // `Record<string, any>` index signature that accepts any attribute, so those pass
+  // regardless of the declaration. These assertions target the call-signature
+  // parameter directly — the exact type TSX consults — without needing a JSX parser.
   type IconAttrs = Parameters<typeof FontAwesomeIcon>[0]
 
   test('accepts class and style', () => {

--- a/types-test/index.test-d.ts
+++ b/types-test/index.test-d.ts
@@ -29,3 +29,35 @@ describe('FontAwesomeIcon icon/mask prop types', () => {
     assertType<Component>(FontAwesomeIcon)
   })
 })
+
+describe('FontAwesomeIcon global attributes (regression: #582)', () => {
+  // Since 3.3.1, FontAwesomeIcon is declared as a FunctionalComponent. In JSX/TSX a
+  // functional component's accepted attributes resolve from the first parameter of
+  // its call signature — so that surface must carry Vue's global component props
+  // (class, style via AllowedComponentProps; key, ref via VNodeProps), or
+  // `<FontAwesomeIcon class="..."/>` fails to type-check (issue #582). The existing
+  // h()-based tests above could not catch this: h()'s RawProps includes a
+  // `Record<string, any>` index signature that accepts any attribute, masking the gap.
+  // These assertions target the call-signature parameter directly — the exact type
+  // TSX consults — without needing a JSX parser.
+  type IconAttrs = Parameters<typeof FontAwesomeIcon>[0]
+
+  test('accepts class and style', () => {
+    assertType<IconAttrs>({ icon: faUser, class: 'my-class' })
+    assertType<IconAttrs>({ icon: faUser, style: { color: 'red' } })
+    assertType<IconAttrs>({ icon: faUser, class: 'my-class', style: { color: 'red' } })
+  })
+
+  test('accepts the reserved key attribute', () => {
+    assertType<IconAttrs>({ icon: faUser, key: 'k' })
+  })
+
+  test('accepts component props alongside global attributes', () => {
+    assertType<IconAttrs>({ icon: 'user', size: '2x', spin: true, class: 'fa-fw' })
+  })
+
+  test('does not widen the attribute surface to any (unknown attributes rejected)', () => {
+    // @ts-expect-error `bogus` is not a valid attribute
+    assertType<IconAttrs>({ icon: faUser, bogus: true })
+  })
+})


### PR DESCRIPTION
## What

This PR fixes the issue #582: 

> since 3.3.1, `class` and `style` on `<FontAwesomeIcon>` fail to type-check in JSX/TSX (`TS2322: Property 'class' does not exist`). 

Runtime is unaffected — the attributes still render — so this is a types-only regression.

Changes:
- `index.d.ts` — the fix (one declaration).
- `types-test/index.test-d.ts` — regression guards that would have caught it.
- `.github/workflows/ci.yml` — type-check the oldest supported Vue, not just the newest.

## Root cause

3.3.1 (#576) fixed a separate problem (TS2590, union too complex in render functions) by changing one line:

```diff
-declare const FontAwesomeIcon: DefineComponent<FontAwesomeIconProps>
+declare const FontAwesomeIcon: FunctionalComponent<FontAwesomeIconProps>
```

In JSX/TSX, a `FunctionalComponent`'s accepted attributes resolve from the first parameter of its call signature — just `FontAwesomeIconProps`. `DefineComponent` additionally merges Vue's global component props (`class`, `style` via `AllowedComponentProps`; `key`, `ref` via `VNodeProps`). Switching to `FunctionalComponent` dropped those, so `class`/`style` disappeared from the TSX attribute surface. Confirmed by compiling a `.tsx` reproduction against the current types: `class` and `style` error, while `key` and `icon="user"` still pass (key/ref arrive via JSX's `IntrinsicAttributes`, and the TS2590 fix is intact).

## The fix

```diff
-import { DefineComponent, FunctionalComponent } from 'vue'
+import { DefineComponent, FunctionalComponent, AllowedComponentProps, VNodeProps } from 'vue'
...
-declare const FontAwesomeIcon: FunctionalComponent<FontAwesomeIconProps>
+declare const FontAwesomeIcon: FunctionalComponent<FontAwesomeIconProps & AllowedComponentProps & VNodeProps>
```

This restores exactly the global attributes `DefineComponent` used to expose, without reintroducing the instance machinery that caused TS2590. `icon={123}` and unknown attributes are still rejected — the surface is not widened to `any`.

## Backward compatibility (this bit needed care)

The obvious formulation — intersecting with Vue's `PublicProps` (which *is* `VNodeProps & AllowedComponentProps & ComponentCustomProps`) — is **not** backward compatible. `PublicProps` only became an *exported* type in Vue 3.4; in 3.0–3.3 it is an internal `declare type`. The peer range is `vue >= 3.0.0`, so importing it would emit `TS2305: no exported member 'PublicProps'` inside our own `.d.ts` for anyone on 3.0–3.3 — and CI would not have caught it, because `test:types` only ran against 3.5.x.

`AllowedComponentProps` and `VNodeProps` are both exported since 3.0.11, so the fix works across the whole range. Verified by compiling the actual `index.d.ts` against each cached Vue version:

| vue | `class`/`style`/`key`/props |
| --- | --- |
| 3.0.11 | ✅ |
| 3.1.5 | ✅ |
| 3.2.47 | ✅ |
| 3.3.13 | ✅ |
| 3.4.38 | ✅ |
| 3.5.39 | ✅ |

Other components are unaffected: `FontAwesomeLayers` and `FontAwesomeLayersText` are declared as `DefineComponent`, which already carries the global props (verified in TSX).

## Why the existing type tests missed it

#576 added type tests, but they exercise `h()`, and `h()`'s `RawProps` includes a `Record<string, any>` index signature — so `h(FontAwesomeIcon, { class: 'x' })` type-checks regardless of the declaration. The regression only surfaces in JSX/TSX, which the tests never covered.

The new guards target `Parameters<typeof FontAwesomeIcon>[0]` — the exact call-signature parameter TSX consults for a functional component — so they catch the regression without needing a JSX parser (vitest 4's typecheck collector can't parse JSX without adding `@vitejs/plugin-vue-jsx`). Confirmed the guards discriminate: they pass on the fixed declaration and fail (`TS2353`) on the broken one.

## CI

`test:types` previously ran only on `vue == 3.5.x`, which is precisely why a 3.0-incompatible type edit could pass unnoticed. It now also runs on the floor (`vue == 3.0.x`); the matrix already swaps in the target Vue before that step. Proven end-to-end: with the `PublicProps` formulation the new floor cell fails (2 type errors); with the shipped fix it passes.

## Verification

- Unit tests: 108/108.
- Type tests: 7/7, no type errors.
- Cross-version `index.d.ts` compile: 3.0.x → 3.5.x all pass.
- Negative guards (`icon={123}`, unknown attribute) still rejected.
- Runtime: unchanged — `.d.ts` only, no bundle change.

Cross-version checks used Vue tarballs already in the local npm cache (offline); the definitive matrix coverage is the CI change above.
